### PR TITLE
Update build SDK and JSON library

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
 
   <!-- Package Versions -->
   <ItemGroup>
-    <PackageVersion Include="JetBrains.Annotations" Version="2021.2.0" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2021.3.0" />
     <PackageVersion Include="MetaBrainz.Common.Json" Version="4.0.1" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.Json" Version="5.0.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   <!-- Package Versions -->
   <ItemGroup>
     <PackageVersion Include="JetBrains.Annotations" Version="2021.2.0" />
-    <PackageVersion Include="MetaBrainz.Common.Json" Version="4.0.0" />
+    <PackageVersion Include="MetaBrainz.Common.Json" Version="4.0.1" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2021 Tim Van Holder
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MetaBrainz.ListenBrainz.sln
+++ b/MetaBrainz.ListenBrainz.sln
@@ -5,11 +5,12 @@ VisualStudioVersion = 15.0.26430.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Support Files", "Support Files", "{F997B31A-CF25-4C63-BEB5-172F7E13D9B3}"
 	ProjectSection(SolutionItems) = preProject
-		README.md = README.md
 		appveyor.yml = appveyor.yml
 		Directory.Packages.props = Directory.Packages.props
-		global.json = global.json
 		.editorconfig = .editorconfig
+		global.json = global.json
+		LICENSE.md = LICENSE.md
+		README.md = README.md
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MetaBrainz.ListenBrainz", "MetaBrainz.ListenBrainz\MetaBrainz.ListenBrainz.csproj", "{7432E8B5-BAEF-4B24-ABE0-3410853F3273}"

--- a/MetaBrainz.ListenBrainz.sln.DotSettings
+++ b/MetaBrainz.ListenBrainz.sln.DotSettings
@@ -11,6 +11,7 @@
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/BLANK_LINES_INSIDE_TYPE/@EntryValue">1</s:Int64>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_CODE/@EntryValue">1</s:Int64>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_DECLARATIONS/@EntryValue">1</s:Int64>
+	<s:String x:Key="/Default/Environment/InlayHints/GeneralInlayHintsOptions/DefaultMode/@EntryValue">PushToShowHints</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>

--- a/MetaBrainz.ListenBrainz/MetaBrainz.ListenBrainz.csproj
+++ b/MetaBrainz.ListenBrainz/MetaBrainz.ListenBrainz.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Title>ListenBrainz Web Service Client Library</Title>
     <Description>This package provides classes for accessing the ListenBrainz API (v1).</Description>
-    <PackageCopyrightYears>2018-2020</PackageCopyrightYears>
+    <PackageCopyrightYears>2018-2021</PackageCopyrightYears>
     <PackageRepositoryName>MetaBrainz.ListenBrainz</PackageRepositoryName>
     <PackageTags>ListenBrainz music metadata listens audioscrobbler last.fm</PackageTags>
     <Version>3.0.0-pre</Version>

--- a/MetaBrainz.ListenBrainz/UnixTime.cs
+++ b/MetaBrainz.ListenBrainz/UnixTime.cs
@@ -8,7 +8,7 @@ namespace MetaBrainz.ListenBrainz {
   [PublicAPI]
   public static class UnixTime {
 
-#if !NETFRAMEWORK // Unix Time support available
+#if NETSTANDARD2_1_OR_GREATER // Unix Time support available
 
     /// <summary>The epoch for Unix time values (1970-01-01T00:00:00Z).</summary>
     public static readonly DateTimeOffset Epoch = DateTimeOffset.UnixEpoch;

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ This is a library providing access to the [ListenBrainz API][LB-API].
 
 #### Dependency Updates
 
-- MetaBrainz.Common.Json → 4.0.0
+- MetaBrainz.Build.Sdk → 1.0.1
+  - This changes the target frameworks to `netstandard2.0`, `netstandard2.1`, and
+    `net472`
+  - This include a change of the license to MIT (from MS-PL)
+- MetaBrainz.Common.Json → 4.0.1
 - System.Text.Json → 5.0.2
 
 ### v2.0.0 (2020-04-27)

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This is a library providing access to the [ListenBrainz API][LB-API].
 
 #### Dependency Updates
 
+- JetBrainz.Annotations → 2021.3.0
 - MetaBrainz.Build.Sdk → 1.0.1
   - This changes the target frameworks to `netstandard2.0`, `netstandard2.1`, and
     `net472`

--- a/global.json
+++ b/global.json
@@ -1,5 +1,5 @@
 {
   "msbuild-sdks": {
-    "MetaBrainz.Build.Sdk" : "1.0.0"
+    "MetaBrainz.Build.Sdk" : "1.0.1"
   }
 }


### PR DESCRIPTION
Updating the SDK implies a license change (MS-PL → MIT) as well as a
different set of target frameworks (`net472`, `netstandard2.0` and
`netstandard2.1`).

This in turn required updating the MetaBrainz.Common.Json dependency to
version 4.0.1, as well as tweaking some of the conditional compilation.

This also updates JetBrains.Annotations to the latest version.