### PR TITLE
Add MBID mapping support

### DIFF
--- a/MetaBrainz.ListenBrainz/Interfaces/IAdditionalInfo.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IAdditionalInfo.cs
@@ -47,6 +47,12 @@ public interface IAdditionalInfo {
   /// <summary>The application used to listed to the track.</summary>
   string? ListeningFrom { get; }
 
+  /// <summary>The name of the program used to listen to the track; this should not include a version number.</summary>
+  string? MediaPlayer { get; }
+
+  /// <summary>The version of the program used to listen to the track.</summary>
+  string? MediaPlayerVersion { get; }
+
   /// <summary>The MessyBrainz ID for the track's artist.</summary>
   Guid? MessyArtistId { get; }
 
@@ -58,6 +64,26 @@ public interface IAdditionalInfo {
 
   /// <summary>The MusicBrainz ID for the track's recording.</summary>
   Guid? RecordingId { get; }
+
+  /// <summary>
+  /// If the track comes from an online service, the canonical domain of this service (so "spotify.com", not something like
+  /// "http://open.spotify.com").
+  /// </summary>
+  string? MusicService { get; }
+
+  /// <summary>
+  /// If the track comes from an online service, a name that represents the service. Only relevant when <see cref="MusicService"/>
+  /// is not set.
+  /// </summary>
+  string? MusicServiceName { get; }
+
+  /// <summary>
+  /// If the song of this listen comes from an online source, the URL to the place where it was available at the time.<br/>
+  /// This could be a spotify url (see <see cref="SpotifyId"/>), a YouTube video URL, a Soundcloud recording page URL, or the full
+  /// URL to a public MP3 file. If there is a webpage for this song (e.g. YouTube page, Soundcloud page), that should be used here
+  /// instead of the URL to an actual audio resource.
+  /// </summary>
+  Uri? OriginUrl { get; }
 
   /// <summary>The artist name for the track's release.</summary>
   string? ReleaseArtistName { get; }
@@ -82,6 +108,15 @@ public interface IAdditionalInfo {
 
   /// <summary>The track's Spotify ID.</summary>
   Uri? SpotifyId { get; }
+
+  /// <summary>
+  /// The name of the client used to submit the listen to ListenBrainz; this should not include a version number.<br/>
+  /// If the media player has the ability to submit listens built in, then this value may be the same as <see cref="MediaPlayer"/>.
+  /// </summary>
+  string? SubmissionClient { get; }
+
+  /// <summary>The version of the client used to submit the listen to ListenBrainz.</summary>
+  string? SubmissionClientVersion { get; }
 
   /// <summary>The track's tags.</summary>
   IReadOnlyList<string?>? Tags { get; }

--- a/MetaBrainz.ListenBrainz/Interfaces/IMusicBrainzIdMappings.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IMusicBrainzIdMappings.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>
+/// Mappings to MusicBrainz IDs as determined by ListenBrainz.<br/>
+/// There are similar fields in <see cref="IAdditionalInfo"/>, but those are values supplied at submission time by the client.
+/// </summary>
+public interface IMusicBrainzIdMappings {
+
+  /// <summary>The MusicBrainz IDs for the track's artists.</summary>
+  IReadOnlyList<Guid>? ArtistIds { get; }
+
+  /// <summary>The MusicBrainz ID for the track's recording.</summary>
+  Guid? RecordingId { get; }
+
+  /// <summary>The MusicBrainz ID for the track's release.</summary>
+  Guid? ReleaseId { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/ITrackInfo.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ITrackInfo.cs
@@ -14,6 +14,12 @@ public interface ITrackInfo : IJsonBasedObject {
   /// <summary>The name of the track's artist.</summary>
   string Artist { get; }
 
+  /// <summary>
+  /// Mappings to MusicBrainz IDs for this track, as determined by ListenBrainz.<br/>
+  /// There are similar fields in <see cref="AdditionalInfo"/>, but those are values supplied at submission time by the client.
+  /// </summary>
+  IMusicBrainzIdMappings? MusicBrainzIdMappings { get; }
+
   /// <summary>The name of the track.</summary>
   string Name { get; }
 

--- a/MetaBrainz.ListenBrainz/Json/Readers/MusicBrainzIdMappingsReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/MusicBrainzIdMappingsReader.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.Common.Json.Converters;
+using MetaBrainz.ListenBrainz.Objects;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers;
+
+internal sealed class MusicBrainzIdMappingsReader : ObjectReader<MusicBrainzIdMappings> {
+  
+  public static readonly MusicBrainzIdMappingsReader Instance = new MusicBrainzIdMappingsReader();
+
+  protected override MusicBrainzIdMappings ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    IReadOnlyList<Guid>? artists = null;
+    Guid? recording = null;
+    Guid? release = null;
+    Dictionary<string, object?>? rest = null;
+    while (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      try {
+        reader.Read();
+        switch (prop) {
+          case "artist_mbids":
+            artists = reader.ReadList<Guid>(options);
+            break;
+          case "recording_mbid":
+            recording = reader.GetOptionalGuid();
+            break;
+          case "release_mbid":
+            release= reader.GetOptionalGuid();
+            break;
+          default:
+            rest ??= new Dictionary<string, object?>();
+            rest[prop] = reader.GetOptionalObject(options);
+            break;
+        }
+      }
+      catch (Exception e) {
+        throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+      }
+      reader.Read();
+    }
+    return new MusicBrainzIdMappings {
+      ArtistIds = artists,
+      RecordingId = recording,
+      ReleaseId = release,
+      UnhandledProperties = rest
+    };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Readers/TrackInfoReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/TrackInfoReader.cs
@@ -18,6 +18,7 @@ internal sealed class TrackInfoReader : ObjectReader<TrackInfo> {
     string? artist = null;
     string? release = null;
     IAdditionalInfo? info = null;
+    IMusicBrainzIdMappings? mapping = null;
     Dictionary<string, object?>? rest = null;
     while (reader.TokenType == JsonTokenType.PropertyName) {
       var prop = reader.GetPropertyName();
@@ -29,6 +30,9 @@ internal sealed class TrackInfoReader : ObjectReader<TrackInfo> {
             break;
           case "artist_name":
             artist = reader.GetString();
+            break;
+          case "mbid_mapping":
+            mapping = reader.GetObject(MusicBrainzIdMappingsReader.Instance, options);
             break;
           case "release_name":
             release = reader.GetString();
@@ -57,6 +61,7 @@ internal sealed class TrackInfoReader : ObjectReader<TrackInfo> {
       throw new JsonException("Expected additional info not found or null.");
     }
     return new TrackInfo(name, artist, info) {
+      MusicBrainzIdMappings = mapping,
       Release = release,
       UnhandledProperties = rest
     };

--- a/MetaBrainz.ListenBrainz/Objects/AdditionalInfo.cs
+++ b/MetaBrainz.ListenBrainz/Objects/AdditionalInfo.cs
@@ -21,9 +21,14 @@ internal sealed class AdditionalInfo : IAdditionalInfo {
     this.Isrc = AdditionalInfo.GetObject<string>(fields, "isrc");
     this.ImportedReleaseId = AdditionalInfo.GetValue<Guid>(fields, "lastfm_release_mbid");
     this.ListeningFrom = AdditionalInfo.GetObject<string>(fields, "listening_from");
+    this.MediaPlayer = AdditionalInfo.GetObject<string>(fields, "media_player");
+    this.MediaPlayerVersion = AdditionalInfo.GetObject<string>(fields, "media_player_version");
     this.MessyArtistId = AdditionalInfo.GetValue<Guid>(fields, "artist_msid");
     this.MessyRecordingId = AdditionalInfo.GetValue<Guid>(fields, "recording_msid");
     this.MessyReleaseId = AdditionalInfo.GetValue<Guid>(fields, "release_msid");
+    this.MusicService = AdditionalInfo.GetObject<string>(fields, "music_service");
+    this.MusicServiceName = AdditionalInfo.GetObject<string>(fields, "music_service_name");
+    this.OriginUrl = AdditionalInfo.GetObject<Uri>(fields, "origin_url");
     this.RecordingId = AdditionalInfo.GetValue<Guid>(fields, "recording_mbid");
     this.ReleaseArtistName = AdditionalInfo.GetObject<string>(fields, "release_artist_name");
     this.ReleaseArtistNames = AdditionalInfo.GetObjectList<string>(fields, "release_artist_names");
@@ -32,7 +37,9 @@ internal sealed class AdditionalInfo : IAdditionalInfo {
     this.SpotifyAlbumId = AdditionalInfo.GetObject<Uri>(fields, "spotify_album_id");
     this.SpotifyAlbumArtistIds = AdditionalInfo.GetObjectList<Uri>(fields, "spotify_album_artist_ids");
     this.SpotifyArtistIds = AdditionalInfo.GetObjectList<Uri>(fields, "spotify_artist_ids");
-    this.SpotifyId = AdditionalInfo.GetObject<Uri>(fields, "spotify_album_id");
+    this.SpotifyId = AdditionalInfo.GetObject<Uri>(fields, "spotify_id");
+    this.SubmissionClient = AdditionalInfo.GetObject<string>(fields, "submission_client");
+    this.SubmissionClientVersion = AdditionalInfo.GetObject<string>(fields, "submission_client_version");
     this.Tags = AdditionalInfo.GetObjectList<string>(fields, "tags");
     this.TrackId = AdditionalInfo.GetValue<Guid>(fields, "track_mbid");
     this.TrackNumber = AdditionalInfo.GetValue<int>(fields, "tracknumber");
@@ -64,11 +71,21 @@ internal sealed class AdditionalInfo : IAdditionalInfo {
 
   public string? ListeningFrom { get; }
 
+  public string? MediaPlayer { get; }
+
+  public string? MediaPlayerVersion { get; }
+
   public Guid? MessyArtistId { get; }
 
   public Guid? MessyRecordingId { get; }
 
   public Guid? MessyReleaseId { get; }
+
+  public string? MusicService { get; }
+
+  public string? MusicServiceName { get; }
+
+  public Uri? OriginUrl { get; }
 
   public Guid? RecordingId { get; }
 
@@ -87,6 +104,10 @@ internal sealed class AdditionalInfo : IAdditionalInfo {
   public IReadOnlyList<Uri?>? SpotifyArtistIds { get; }
 
   public Uri? SpotifyId { get; }
+
+  public string? SubmissionClient { get; }
+
+  public string? SubmissionClientVersion { get; }
 
   public IReadOnlyList<string?>? Tags { get; }
 

--- a/MetaBrainz.ListenBrainz/Objects/MusicBrainzIdMappings.cs
+++ b/MetaBrainz.ListenBrainz/Objects/MusicBrainzIdMappings.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+
+using JetBrains.Annotations;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
+internal sealed class MusicBrainzIdMappings : JsonBasedObject, IMusicBrainzIdMappings {
+  
+  public IReadOnlyList<Guid>? ArtistIds { get; set; }
+
+  public Guid? RecordingId { get; set; }
+
+  public Guid? ReleaseId { get; set; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/TrackInfo.cs
+++ b/MetaBrainz.ListenBrainz/Objects/TrackInfo.cs
@@ -18,6 +18,8 @@ internal sealed class TrackInfo : JsonBasedObject, ITrackInfo {
 
   public string Artist { get; }
 
+  public IMusicBrainzIdMappings? MusicBrainzIdMappings { get; set; }
+
   public string Name { get; }
 
   public string? Release { get; set; }


### PR DESCRIPTION
They are kept separate, as in the response, and not applied to AdditionalInfo (because there is no clear "right value").

This also adds a few fields to AdditionalInfo, based on the API documentation:
- `MediaPlayer` and `MediaPlayerVersion`
- `MusicService` and `MusicServiceName`
- `OriginUrl`
- `SubmissionClient` and `SubmissionClientVersion`

In addition, the existing `SpotifyId` field is now correct (it used to get the album ID).