### PR TITLE
Fix JSON serialization for submissions

### DIFF
--- a/MetaBrainz.ListenBrainz/ListenBrainz.cs
+++ b/MetaBrainz.ListenBrainz/ListenBrainz.cs
@@ -610,7 +610,7 @@ public sealed class ListenBrainz : IDisposable {
 
   #region /1/submit-listens
 
-  private ConfiguredTaskAwaitable SubmitListensAsync(SubmissionPayload payload)
+  private ConfiguredTaskAwaitable SubmitListensAsync<T>(T payload)
     => this.PostAsync("submit-listens", payload).ConfigureAwait(false);
 
   private ConfiguredTaskAwaitable SubmitListensAsync(string payload)


### PR DESCRIPTION
Currently we expect the `T` type in `PostAsync()` to be the exact type to use for serialization (no `GetType()` used).

However, `SubmitListensAsync()` took a `SubmissionPayload`, causing the proper writers to be ignored. Now it takes an unconstrained `T` to resolve that issue.