### PR TITLE
Update the build SDK to version 3.1.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,13 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+      - "dependencies"
+      - "nuget"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+      - "gh-actions"

--- a/.github/github-labels.yml
+++ b/.github/github-labels.yml
@@ -36,6 +36,14 @@
   color: '008672'
   description: "Changes related to unit tests"
 
+# Additional Labels Used by Dependabot
+- name: gh-actions
+  color: '1d0128'
+  description: "Version updates for GitHub actions"
+- name: nuget
+  color: '1d0128'
+  description: "Version updates for NuGet packages"
+
 # Additional Labels for Release Drafter Version Resolution
 - name: bump-major-version
   color: 'cf996b'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,52 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - 'main'
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      dotnet-version: 8.0.x
+    strategy:
+      matrix:
+        configuration: ['Debug', 'Release']
+
+    steps:
+    - name: Check out the project
+      uses: actions/checkout@v4
+    - name: Set up .NET ${{env.dotnet-version}}
+      uses: actions/setup-dotnet@v4
+      id: setup
+      with:
+        dotnet-version: ${{env.dotnet-version}}
+      env:
+        NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    - name: Create global.json to force use of .NET SDK ${{steps.setup.outputs.dotnet-version}}
+      run: echo '{"sdk":{"version":"${{steps.setup.outputs.dotnet-version}}"}}' > ./global.json
+    - name: Run build script (${{matrix.configuration}})
+      run: pwsh ./build-package.ps1 -ContinuousIntegration -WithBinLog -Configuration ${{matrix.configuration}}
+    - name: "Artifact: MSBuild Logs"
+      uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: MSBuild Logs (${{matrix.configuration}})
+        path: msbuild.*.binlog
+    - name: "Artifact: NuGet Packages"
+      uses: actions/upload-artifact@v3
+      with:
+        name: NuGet Packages (${{matrix.configuration}})
+        path: "output/package/${{matrix.configuration}}/*.*nupkg"
+    - name: Publish (NuGet - GitHub Packages)
+      if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
+      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg -s https://nuget.pkg.github.com/zastai/index.json -k ${{secrets.GITHUB_TOKEN}}"
+    - name: Publish (NuGet - nuget.org)
+      if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
+      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,6 +10,6 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v5.15.0
+      - uses: release-drafter/release-drafter@v5.25.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-labels.yml
+++ b/.github/workflows/update-labels.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Labeler
         if: success()
-        uses: crazy-max/ghaction-github-labeler@v3
+        uses: crazy-max/ghaction-github-labeler@v5
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           yaml-file: .github/github-labels.yml

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2021 Tim Van Holder
+Copyright (c) 2018, 2019, 2020, 2021, 2022, 2023 Tim Van Holder
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MetaBrainz.ListenBrainz.sln
+++ b/MetaBrainz.ListenBrainz.sln
@@ -8,10 +8,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Support Files", "Support Fi
 		.editorconfig = .editorconfig
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
-		appveyor.yml = appveyor.yml
 		build-package.ps1 = build-package.ps1
 		Directory.Packages.props = Directory.Packages.props
-		global.json = global.json
 		LICENSE.md = LICENSE.md
 		package-icon.png = package-icon.png
 		README.md = README.md
@@ -26,6 +24,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GitHub", "GitHub", "{9968DB
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Actions", "Actions", "{5C86A695-952F-4F35-BBB8-BD547130215C}"
 	ProjectSection(SolutionItems) = preProject
+		.github\workflows\build.yml = .github\workflows\build.yml
 		.github\workflows\release-drafter.yml = .github\workflows\release-drafter.yml
 		.github\workflows\update-labels.yml = .github\workflows\update-labels.yml
 	EndProjectSection

--- a/MetaBrainz.ListenBrainz/MetaBrainz.ListenBrainz.csproj
+++ b/MetaBrainz.ListenBrainz/MetaBrainz.ListenBrainz.csproj
@@ -1,20 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="MetaBrainz.Build.Sdk">
+<Project>
+
+  <Sdk Name="MetaBrainz.Build.Sdk" Version="3.1.0" />
 
   <PropertyGroup>
+    <Authors>Zastai</Authors>
     <Title>ListenBrainz Web Service Client Library</Title>
     <Description>This package provides classes for accessing the ListenBrainz API (v1).</Description>
-    <PackageCopyrightYears>2018-2021</PackageCopyrightYears>
+    <PackageCopyrightOwners>Tim Van Holder</PackageCopyrightOwners>
+    <PackageCopyrightYears>2018, 2019, 2020, 2021, 2022, 2023</PackageCopyrightYears>
     <PackageRepositoryName>MetaBrainz.ListenBrainz</PackageRepositoryName>
     <PackageTags>ListenBrainz music metadata listens audioscrobbler last.fm</PackageTags>
     <Version>4.0.0-pre</Version>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <AssemblyIsComVisible>false</AssemblyIsComVisible>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" IncludeAssets="compile" PrivateAssets="all" />
     <PackageReference Include="MetaBrainz.Common.Json" />
-    <PackageReference Include="System.Net.Http" />
-    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
 </Project>

--- a/MetaBrainz.ListenBrainz/Properties/AssemblyInfo.cs
+++ b/MetaBrainz.ListenBrainz/Properties/AssemblyInfo.cs
@@ -1,3 +1,0 @@
-using System.Runtime.InteropServices;
-
-[assembly: ComVisible(false)]

--- a/MetaBrainz.ListenBrainz/QueryException.cs
+++ b/MetaBrainz.ListenBrainz/QueryException.cs
@@ -1,11 +1,9 @@
 using System;
 using System.Net;
-using System.Runtime.Serialization;
 
 namespace MetaBrainz.ListenBrainz;
 
 /// <summary>An error reported by the ListenBrainz web service.</summary>
-[Serializable]
 public sealed class QueryException : Exception {
 
   /// <summary>The HTTP status code for the exception.</summary>
@@ -24,22 +22,5 @@ public sealed class QueryException : Exception {
     this.Code = code;
     this.Reason = reason;
   }
-
-  #region ISerializable
-
-  /// <inheritdoc />
-  public QueryException(SerializationInfo info, StreamingContext context) : base(info, context) {
-    this.Code = (HttpStatusCode) info.GetInt32("query:code");
-    this.Reason = info.GetString("query:reason") ?? "???";
-  }
-
-  /// <inheritdoc />
-  public override void GetObjectData(SerializationInfo info, StreamingContext context) {
-    base.GetObjectData(info, context);
-    info.AddValue("query:code", (int) this.Code);
-    info.AddValue("query:reason", this.Reason);
-  }
-
-  #endregion
 
 }

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This is a library providing access to the [ListenBrainz API][LB-API].
 [ListenBrainz][LB] keeps track of users' listens of music tracks
 (similar to sites like [last.fm][LastFM] and [libre.fm][LibreFM]).
 
-[CI-S]: https://img.shields.io/appveyor/build/zastai/metabrainz-listenbrainz
-[CI-L]: https://ci.appveyor.com/project/Zastai/metabrainz-listenbrainz
+[CI-S]: https://github.com/Zastai/MetaBrainz.ListenBrainz/actions/workflows/build.yml/badge.svg
+[CI-L]: https://github.com/Zastai/MetaBrainz.ListenBrainz/actions/workflows/build.yml
 [NuGet-S]: https://img.shields.io/nuget/v/MetaBrainz.ListenBrainz
 [NuGet-L]: https://nuget.org/packages/MetaBrainz.ListenBrainz
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,0 @@
-version: 'Build #{build}'
-image: Visual Studio 2022
-build_script:
-  - ps: .\build-package.ps1 -Configuration Debug
-after_build:
-  - ps: Get-ChildItem output/package/*/*.nupkg | % { appveyor PushArtifact $_ }

--- a/build-package.ps1
+++ b/build-package.ps1
@@ -3,6 +3,7 @@
 [CmdletBinding()]
 param (
   [string] $Configuration = 'Release',
+  [switch] $ContinuousIntegration = $false,
   [switch] $WithBinLog = $false
 )
 
@@ -41,7 +42,15 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 Write-Host "Building the solution (Configuration: $Configuration)..."
-dotnet build $opts --no-restore "-c:$Configuration" '-p:ContinuousIntegrationBuild=true' '-p:Deterministic=true'
+$props = @()
+if ($ContinuousIntegration) {
+  $props += '-p:ContinuousIntegrationBuild=true'
+  $props += '-p:Deterministic=true'
+}
+if ($Configuration -eq 'Debug') {
+  $props += '-p:DebugMessageImportance=high'
+}
+dotnet build $opts --no-restore "-c:$Configuration" $props
 Complete-BuildStep 'build'
 if ($LASTEXITCODE -ne 0) {
   Write-Error "SOLUTION BUILD FAILED"

--- a/global.json
+++ b/global.json
@@ -1,5 +1,0 @@
-{
-  "msbuild-sdks": {
-    "MetaBrainz.Build.Sdk" : "2.1.2"
-  }
-}

--- a/public-api/MetaBrainz.ListenBrainz.net6.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net6.0.cs.md
@@ -1,0 +1,1105 @@
+﻿# API Reference: MetaBrainz.ListenBrainz
+
+## Assembly Attributes
+
+```cs
+[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v6.0", FrameworkDisplayName = ".NET 6.0")]
+```
+
+## Namespace: MetaBrainz.ListenBrainz
+
+### Type: ListenBrainz
+
+```cs
+public sealed class ListenBrainz : System.IDisposable {
+
+  public const int DefaultItemsPerGet = 25;
+
+  public const int DefaultTimeRange = 3;
+
+  public const int MaxItemsPerGet = 100;
+
+  public const int MaxListenSize = 10240;
+
+  public const int MaxTagLength = 64;
+
+  public const int MaxTagsPerListen = 50;
+
+  public const int MaxTimeRange = 73;
+
+  public const string UserAgentUrl = "https://github.com/Zastai/ListenBrainz";
+
+  public const string WebServiceRoot = "/1/";
+
+  System.Uri BaseUri {
+    public get;
+  }
+
+  System.Uri ContactInfo {
+    public get;
+  }
+
+  System.Uri? DefaultContactInfo {
+    public static get;
+    public static set;
+  }
+
+  int DefaultPort {
+    public static get;
+    public static set;
+  }
+
+  System.Net.Http.Headers.ProductHeaderValue? DefaultProductInfo {
+    public static get;
+    public static set;
+  }
+
+  string DefaultServer {
+    public static get;
+    public static set;
+  }
+
+  string DefaultUrlScheme {
+    public static get;
+    public static set;
+  }
+
+  string? DefaultUserToken {
+    public static get;
+    public static set;
+  }
+
+  int Port {
+    public get;
+    public set;
+  }
+
+  System.Net.Http.Headers.ProductHeaderValue ProductInfo {
+    public get;
+  }
+
+  MetaBrainz.Common.RateLimitInfo RateLimitInfo {
+    public get;
+  }
+
+  string Server {
+    public get;
+    public set;
+  }
+
+  string UrlScheme {
+    public get;
+    public set;
+  }
+
+  string? UserToken {
+    public get;
+    public set;
+  }
+
+  public ListenBrainz();
+
+  public ListenBrainz(System.Net.Http.Headers.ProductHeaderValue product);
+
+  public ListenBrainz(System.Net.Http.Headers.ProductHeaderValue product, System.Uri contact);
+
+  public ListenBrainz(System.Net.Http.Headers.ProductHeaderValue product, string contact);
+
+  public ListenBrainz(System.Uri contact);
+
+  public ListenBrainz(string contact);
+
+  public ListenBrainz(string application, System.Version version);
+
+  public ListenBrainz(string application, System.Version version, System.Uri contact);
+
+  public ListenBrainz(string application, System.Version version, string contact);
+
+  public ListenBrainz(string application, string version);
+
+  public ListenBrainz(string application, string version, System.Uri contact);
+
+  public ListenBrainz(string application, string version, string contact);
+
+  public void Close();
+
+  public sealed override void Dispose();
+
+  protected override void Finalize();
+
+  public MetaBrainz.ListenBrainz.Interfaces.IUserArtistMap? GetArtistMap(string user, StatisticsRange? range = default, bool forceRecalculation = false);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IUserArtistMap?> GetArtistMapAsync(string user, StatisticsRange? range = default, bool forceRecalculation = false, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.ISiteArtistStatistics? GetArtistStatistics(int? count = default, int? offset = default, StatisticsRange? range = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IUserArtistStatistics? GetArtistStatistics(string user, int? count = default, int? offset = default, StatisticsRange? range = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.ISiteArtistStatistics?> GetArtistStatisticsAsync(int? count = default, int? offset = default, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IUserArtistStatistics?> GetArtistStatisticsAsync(string user, int? count = default, int? offset = default, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IUserDailyActivity? GetDailyActivity(string user, StatisticsRange? range = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IUserDailyActivity?> GetDailyActivityAsync(string user, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.ILatestImport GetLatestImport(string user);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.ILatestImport> GetLatestImportAsync(string user, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IListenCount GetListenCount(string user);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IListenCount> GetListenCountAsync(string user, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IUserListeningActivity? GetListeningActivity(string user, StatisticsRange? range = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IUserListeningActivity?> GetListeningActivityAsync(string user, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IFetchedListens GetListens(string user, int? count = default, int? timeRange = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IFetchedListens GetListensAfter(string user, System.DateTimeOffset after, int? count = default, int? timeRange = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IFetchedListens GetListensAfter(string user, long after, int? count = default, int? timeRange = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IFetchedListens> GetListensAfterAsync(string user, System.DateTimeOffset after, int? count = default, int? timeRange = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IFetchedListens> GetListensAfterAsync(string user, long after, int? count = default, int? timeRange = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IFetchedListens> GetListensAsync(string user, int? count = default, int? timeRange = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IFetchedListens GetListensBefore(string user, System.DateTimeOffset before, int? count = default, int? timeRange = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IFetchedListens GetListensBefore(string user, long before, int? count = default, int? timeRange = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IFetchedListens> GetListensBeforeAsync(string user, System.DateTimeOffset before, int? count = default, int? timeRange = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IFetchedListens> GetListensBeforeAsync(string user, long before, int? count = default, int? timeRange = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IFetchedListens GetListensBetween(string user, System.DateTimeOffset after, System.DateTimeOffset before, int? count = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IFetchedListens GetListensBetween(string user, long after, long before, int? count = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IFetchedListens> GetListensBetweenAsync(string user, System.DateTimeOffset after, System.DateTimeOffset before, int? count = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IFetchedListens> GetListensBetweenAsync(string user, long after, long before, int? count = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IPlayingNow GetPlayingNow(string user);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IPlayingNow> GetPlayingNowAsync(string user, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IRecentListens GetRecentListens(System.Collections.Generic.IEnumerable<string> users);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IRecentListens GetRecentListens(int limit, System.Collections.Generic.IEnumerable<string> users);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IRecentListens GetRecentListens(int limit, params string[] users);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IRecentListens GetRecentListens(params string[] users);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IRecentListens> GetRecentListensAsync(System.Collections.Generic.IEnumerable<string> users, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IRecentListens> GetRecentListensAsync(System.Threading.CancellationToken cancellationToken, params string[] users);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IRecentListens> GetRecentListensAsync(int limit, System.Collections.Generic.IEnumerable<string> users, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IRecentListens> GetRecentListensAsync(int limit, System.Threading.CancellationToken cancellationToken, params string[] users);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IRecentListens> GetRecentListensAsync(int limit, params string[] users);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IRecentListens> GetRecentListensAsync(params string[] users);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IUserRecordingStatistics? GetRecordingStatistics(string user, int? count = default, int? offset = default, StatisticsRange? range = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IUserRecordingStatistics?> GetRecordingStatisticsAsync(string user, int? count = default, int? offset = default, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IUserReleaseStatistics? GetReleaseStatistics(string user, int? count = default, int? offset = default, StatisticsRange? range = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IUserReleaseStatistics?> GetReleaseStatisticsAsync(string user, int? count = default, int? offset = default, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public void ImportListens(params MetaBrainz.ListenBrainz.Interfaces.ISubmittedListen[] listens);
+
+  public void ImportListens(System.Collections.Generic.IEnumerable<MetaBrainz.ListenBrainz.Interfaces.ISubmittedListen> listens);
+
+  public System.Threading.Tasks.Task ImportListensAsync(params MetaBrainz.ListenBrainz.Interfaces.ISubmittedListen[] listens);
+
+  public System.Threading.Tasks.Task ImportListensAsync(System.Collections.Generic.IAsyncEnumerable<MetaBrainz.ListenBrainz.Interfaces.ISubmittedListen> listens, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task ImportListensAsync(System.Collections.Generic.IEnumerable<MetaBrainz.ListenBrainz.Interfaces.ISubmittedListen> listens, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task ImportListensAsync(System.Threading.CancellationToken cancellationToken, params MetaBrainz.ListenBrainz.Interfaces.ISubmittedListen[] listens);
+
+  public void SetLatestImport(string user, System.DateTimeOffset timestamp);
+
+  public void SetLatestImport(string user, long timestamp);
+
+  public System.Threading.Tasks.Task SetLatestImportAsync(string user, System.DateTimeOffset timestamp, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task SetLatestImportAsync(string user, long timestamp, System.Threading.CancellationToken cancellationToken = default);
+
+  public void SetNowPlaying(MetaBrainz.ListenBrainz.Interfaces.ISubmittedListenData listen);
+
+  public void SetNowPlaying(string track, string artist, string? release = null);
+
+  public System.Threading.Tasks.Task SetNowPlayingAsync(MetaBrainz.ListenBrainz.Interfaces.ISubmittedListenData listen, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task SetNowPlayingAsync(string track, string artist, string? release = null, System.Threading.CancellationToken cancellationToken = default);
+
+  public void SubmitSingleListen(MetaBrainz.ListenBrainz.Interfaces.ISubmittedListen listen);
+
+  public void SubmitSingleListen(System.DateTimeOffset timestamp, string track, string artist, string? release = null);
+
+  public void SubmitSingleListen(long timestamp, string track, string artist, string? release = null);
+
+  public void SubmitSingleListen(string track, string artist, string? release = null);
+
+  public System.Threading.Tasks.Task SubmitSingleListenAsync(MetaBrainz.ListenBrainz.Interfaces.ISubmittedListen listen, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task SubmitSingleListenAsync(System.DateTimeOffset timestamp, string track, string artist, string? release = null, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task SubmitSingleListenAsync(long timestamp, string track, string artist, string? release = null, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task SubmitSingleListenAsync(string track, string artist, string? release = null, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.ITokenValidationResult ValidateToken(string token);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.ITokenValidationResult> ValidateTokenAsync(string token, System.Threading.CancellationToken cancellationToken = default);
+
+}
+```
+
+### Type: QueryException
+
+```cs
+public sealed class QueryException : System.Exception {
+
+  public readonly System.Net.HttpStatusCode Code;
+
+  public readonly string? Reason;
+
+  public QueryException(System.Net.HttpStatusCode code, string? reason = null, string? message = null, System.Exception? cause = null);
+
+}
+```
+
+### Type: StatisticsRange
+
+```cs
+public enum StatisticsRange {
+
+  AllTime = 0,
+  Month = 2,
+  Unknown = 4,
+  Week = 1,
+  Year = 3,
+
+}
+```
+
+## Namespace: MetaBrainz.ListenBrainz.Interfaces
+
+### Type: IAdditionalInfo
+
+```cs
+public interface IAdditionalInfo {
+
+  System.Collections.Generic.IReadOnlyDictionary<string, object?> AllFields {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<System.Guid?>? ArtistIds {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<string?>? ArtistNames {
+    public abstract get;
+  }
+
+  int? DiscNumber {
+    public abstract get;
+  }
+
+  System.TimeSpan? Duration {
+    public abstract get;
+  }
+
+  System.Guid? ImportedArtistId {
+    public abstract get;
+  }
+
+  System.Guid? ImportedReleaseId {
+    public abstract get;
+  }
+
+  string? Isrc {
+    public abstract get;
+  }
+
+  string? ListeningFrom {
+    public abstract get;
+  }
+
+  string? MediaPlayer {
+    public abstract get;
+  }
+
+  string? MediaPlayerVersion {
+    public abstract get;
+  }
+
+  System.Guid? MessyArtistId {
+    public abstract get;
+  }
+
+  System.Guid? MessyRecordingId {
+    public abstract get;
+  }
+
+  System.Guid? MessyReleaseId {
+    public abstract get;
+  }
+
+  string? MusicService {
+    public abstract get;
+  }
+
+  string? MusicServiceName {
+    public abstract get;
+  }
+
+  System.Uri? OriginUrl {
+    public abstract get;
+  }
+
+  System.Guid? RecordingId {
+    public abstract get;
+  }
+
+  string? ReleaseArtistName {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<string?>? ReleaseArtistNames {
+    public abstract get;
+  }
+
+  System.Guid? ReleaseGroupId {
+    public abstract get;
+  }
+
+  System.Guid? ReleaseId {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<System.Uri?>? SpotifyAlbumArtistIds {
+    public abstract get;
+  }
+
+  System.Uri? SpotifyAlbumId {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<System.Uri?>? SpotifyArtistIds {
+    public abstract get;
+  }
+
+  System.Uri? SpotifyId {
+    public abstract get;
+  }
+
+  string? SubmissionClient {
+    public abstract get;
+  }
+
+  string? SubmissionClientVersion {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<string?>? Tags {
+    public abstract get;
+  }
+
+  System.Guid? TrackId {
+    public abstract get;
+  }
+
+  int? TrackNumber {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<System.Guid?>? WorkIds {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IArtistCountryInfo
+
+```cs
+public interface IArtistCountryInfo {
+
+  int ArtistCount {
+    public abstract get;
+  }
+
+  string Country {
+    public abstract get;
+  }
+
+  int ListenCount {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IArtistInfo
+
+```cs
+public interface IArtistInfo : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.Collections.Generic.IReadOnlyList<System.Guid>? Ids {
+    public abstract get;
+  }
+
+  int ListenCount {
+    public abstract get;
+  }
+
+  System.Guid? MessyId {
+    public abstract get;
+  }
+
+  string Name {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IArtistStatistics
+
+```cs
+public interface IArtistStatistics {
+
+  System.Collections.Generic.IReadOnlyList<IArtistInfo>? Artists {
+    public abstract get;
+  }
+
+  int Count {
+    public abstract get;
+  }
+
+  int Offset {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IDailyActivity
+
+```cs
+public interface IDailyActivity : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.Collections.Generic.IReadOnlyList<IHourlyActivity>? Friday {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IHourlyActivity>? Monday {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IHourlyActivity>? Saturday {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IHourlyActivity>? Sunday {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IHourlyActivity>? Thursday {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IHourlyActivity>? Tuesday {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IHourlyActivity>? Wednesday {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IFetchedListens
+
+```cs
+public interface IFetchedListens : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.Collections.Generic.IReadOnlyList<IListen> Listens {
+    public abstract get;
+  }
+
+  System.DateTimeOffset Timestamp {
+    public abstract get;
+  }
+
+  long UnixTimestamp {
+    public abstract get;
+  }
+
+  string User {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IHourlyActivity
+
+```cs
+public interface IHourlyActivity : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  int Hour {
+    public abstract get;
+  }
+
+  int ListenCount {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: ILatestImport
+
+```cs
+public interface ILatestImport : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.DateTimeOffset? Timestamp {
+    public abstract get;
+  }
+
+  long? UnixTimestamp {
+    public abstract get;
+  }
+
+  string? User {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IListen
+
+```cs
+public interface IListen : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  string InsertedAt {
+    public abstract get;
+  }
+
+  System.Guid MessyRecordingId {
+    public abstract get;
+  }
+
+  System.DateTimeOffset Timestamp {
+    public abstract get;
+  }
+
+  ITrackInfo Track {
+    public abstract get;
+  }
+
+  long UnixTimestamp {
+    public abstract get;
+  }
+
+  string User {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IListenCount
+
+```cs
+public interface IListenCount : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  long Count {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IListenTimeRange
+
+```cs
+public interface IListenTimeRange {
+
+  string Description {
+    public abstract get;
+  }
+
+  int ListenCount {
+    public abstract get;
+  }
+
+  System.DateTimeOffset? RangeEnd {
+    public abstract get;
+  }
+
+  System.DateTimeOffset? RangeStart {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IMusicBrainzIdMappings
+
+```cs
+public interface IMusicBrainzIdMappings {
+
+  System.Collections.Generic.IReadOnlyList<System.Guid>? ArtistIds {
+    public abstract get;
+  }
+
+  System.Guid? RecordingId {
+    public abstract get;
+  }
+
+  System.Guid? ReleaseId {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IPlayingNow
+
+```cs
+public interface IPlayingNow : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  IPlayingTrack? Track {
+    public abstract get;
+  }
+
+  string User {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IPlayingTrack
+
+```cs
+public interface IPlayingTrack : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  ITrackInfo Info {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IRecentListens
+
+```cs
+public interface IRecentListens : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.Collections.Generic.IReadOnlyList<IListen> Listens {
+    public abstract get;
+  }
+
+  string UserList {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IRecordingInfo
+
+```cs
+public interface IRecordingInfo {
+
+  System.Collections.Generic.IReadOnlyList<System.Guid>? ArtistIds {
+    public abstract get;
+  }
+
+  System.Guid? ArtistMessyId {
+    public abstract get;
+  }
+
+  string? ArtistName {
+    public abstract get;
+  }
+
+  System.Guid? Id {
+    public abstract get;
+  }
+
+  int ListenCount {
+    public abstract get;
+  }
+
+  System.Guid? MessyId {
+    public abstract get;
+  }
+
+  string Name {
+    public abstract get;
+  }
+
+  System.Guid? ReleaseId {
+    public abstract get;
+  }
+
+  System.Guid? ReleaseMessyId {
+    public abstract get;
+  }
+
+  string? ReleaseName {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IReleaseInfo
+
+```cs
+public interface IReleaseInfo {
+
+  System.Collections.Generic.IReadOnlyList<System.Guid>? ArtistIds {
+    public abstract get;
+  }
+
+  System.Guid? ArtistMessyId {
+    public abstract get;
+  }
+
+  string? ArtistName {
+    public abstract get;
+  }
+
+  System.Guid? Id {
+    public abstract get;
+  }
+
+  int ListenCount {
+    public abstract get;
+  }
+
+  System.Guid? MessyId {
+    public abstract get;
+  }
+
+  string Name {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: ISiteArtistStatistics
+
+```cs
+public interface ISiteArtistStatistics : IArtistStatistics, IStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
+
+}
+```
+
+### Type: IStatistics
+
+```cs
+public interface IStatistics : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.DateTimeOffset LastUpdated {
+    public abstract get;
+  }
+
+  System.DateTimeOffset? NewestListen {
+    public abstract get;
+  }
+
+  System.DateTimeOffset? OldestListen {
+    public abstract get;
+  }
+
+  MetaBrainz.ListenBrainz.StatisticsRange Range {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: ISubmittedListen
+
+```cs
+public interface ISubmittedListen : ISubmittedListenData {
+
+  System.DateTimeOffset Timestamp {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: ISubmittedListenData
+
+```cs
+public interface ISubmittedListenData {
+
+  ISubmittedTrackInfo Track {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: ISubmittedTrackInfo
+
+```cs
+public interface ISubmittedTrackInfo {
+
+  System.Collections.Generic.IReadOnlyDictionary<string, object?>? AdditionalInfo {
+    public abstract get;
+  }
+
+  string Artist {
+    public abstract get;
+  }
+
+  string Name {
+    public abstract get;
+  }
+
+  string? Release {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: ITokenValidationResult
+
+```cs
+public interface ITokenValidationResult {
+
+  System.Net.HttpStatusCode Code {
+    public abstract get;
+  }
+
+  string Message {
+    public abstract get;
+  }
+
+  string? User {
+    public abstract get;
+  }
+
+  bool? Valid {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: ITrackInfo
+
+```cs
+public interface ITrackInfo : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  IAdditionalInfo AdditionalInfo {
+    public abstract get;
+  }
+
+  string Artist {
+    public abstract get;
+  }
+
+  IMusicBrainzIdMappings? MusicBrainzIdMappings {
+    public abstract get;
+  }
+
+  string Name {
+    public abstract get;
+  }
+
+  string? Release {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IUserArtistMap
+
+```cs
+public interface IUserArtistMap : IStatistics, IUserStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.Collections.Generic.IReadOnlyList<IArtistCountryInfo>? Countries {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IUserArtistStatistics
+
+```cs
+public interface IUserArtistStatistics : IArtistStatistics, IStatistics, IUserStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
+
+  int TotalCount {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IUserDailyActivity
+
+```cs
+public interface IUserDailyActivity : IStatistics, IUserStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
+
+  IDailyActivity? Activity {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IUserListeningActivity
+
+```cs
+public interface IUserListeningActivity : IStatistics, IUserStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.Collections.Generic.IReadOnlyList<IListenTimeRange>? Activity {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IUserRecordingStatistics
+
+```cs
+public interface IUserRecordingStatistics : IStatistics, IUserStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
+
+  int? Offset {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IRecordingInfo>? Recordings {
+    public abstract get;
+  }
+
+  int? TotalCount {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IUserReleaseStatistics
+
+```cs
+public interface IUserReleaseStatistics : IStatistics, IUserStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
+
+  int? Offset {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IReleaseInfo>? Releases {
+    public abstract get;
+  }
+
+  int? TotalCount {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IUserStatistics
+
+```cs
+public interface IUserStatistics : IStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
+
+  string User {
+    public abstract get;
+  }
+
+}
+```
+
+## Namespace: MetaBrainz.ListenBrainz.Objects
+
+### Type: SubmittedListen
+
+```cs
+public class SubmittedListen : SubmittedListenData, MetaBrainz.ListenBrainz.Interfaces.ISubmittedListen, MetaBrainz.ListenBrainz.Interfaces.ISubmittedListenData {
+
+  System.DateTimeOffset Timestamp {
+    public sealed override get;
+    public set;
+  }
+
+  public SubmittedListen(System.DateTimeOffset timestamp, string track, string artist, string? release = null);
+
+  public SubmittedListen(long timestamp, string track, string artist, string? release = null);
+
+  public SubmittedListen(string track, string artist, string? release = null);
+
+}
+```
+
+### Type: SubmittedListenData
+
+```cs
+public class SubmittedListenData : MetaBrainz.ListenBrainz.Interfaces.ISubmittedListenData {
+
+  public readonly SubmittedTrackInfo Track;
+
+  public SubmittedListenData(string track, string artist, string? release = null);
+
+}
+```
+
+### Type: SubmittedTrackInfo
+
+```cs
+public class SubmittedTrackInfo : MetaBrainz.ListenBrainz.Interfaces.ISubmittedTrackInfo {
+
+  System.Collections.Generic.Dictionary<string, object?>? AdditionalInfo {
+    public get;
+    public set;
+  }
+
+  string Artist {
+    public sealed override get;
+    public set;
+  }
+
+  string Name {
+    public sealed override get;
+    public set;
+  }
+
+  string? Release {
+    public sealed override get;
+    public set;
+  }
+
+  public SubmittedTrackInfo(string name, string artist, string? release = null);
+
+}
+```

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -1,0 +1,1105 @@
+﻿# API Reference: MetaBrainz.ListenBrainz
+
+## Assembly Attributes
+
+```cs
+[assembly: System.Runtime.InteropServices.ComVisibleAttribute(false)]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETCoreApp,Version=v8.0", FrameworkDisplayName = ".NET 8.0")]
+```
+
+## Namespace: MetaBrainz.ListenBrainz
+
+### Type: ListenBrainz
+
+```cs
+public sealed class ListenBrainz : System.IDisposable {
+
+  public const int DefaultItemsPerGet = 25;
+
+  public const int DefaultTimeRange = 3;
+
+  public const int MaxItemsPerGet = 100;
+
+  public const int MaxListenSize = 10240;
+
+  public const int MaxTagLength = 64;
+
+  public const int MaxTagsPerListen = 50;
+
+  public const int MaxTimeRange = 73;
+
+  public const string UserAgentUrl = "https://github.com/Zastai/ListenBrainz";
+
+  public const string WebServiceRoot = "/1/";
+
+  System.Uri BaseUri {
+    public get;
+  }
+
+  System.Uri ContactInfo {
+    public get;
+  }
+
+  System.Uri? DefaultContactInfo {
+    public static get;
+    public static set;
+  }
+
+  int DefaultPort {
+    public static get;
+    public static set;
+  }
+
+  System.Net.Http.Headers.ProductHeaderValue? DefaultProductInfo {
+    public static get;
+    public static set;
+  }
+
+  string DefaultServer {
+    public static get;
+    public static set;
+  }
+
+  string DefaultUrlScheme {
+    public static get;
+    public static set;
+  }
+
+  string? DefaultUserToken {
+    public static get;
+    public static set;
+  }
+
+  int Port {
+    public get;
+    public set;
+  }
+
+  System.Net.Http.Headers.ProductHeaderValue ProductInfo {
+    public get;
+  }
+
+  MetaBrainz.Common.RateLimitInfo RateLimitInfo {
+    public get;
+  }
+
+  string Server {
+    public get;
+    public set;
+  }
+
+  string UrlScheme {
+    public get;
+    public set;
+  }
+
+  string? UserToken {
+    public get;
+    public set;
+  }
+
+  public ListenBrainz();
+
+  public ListenBrainz(System.Net.Http.Headers.ProductHeaderValue product);
+
+  public ListenBrainz(System.Net.Http.Headers.ProductHeaderValue product, System.Uri contact);
+
+  public ListenBrainz(System.Net.Http.Headers.ProductHeaderValue product, string contact);
+
+  public ListenBrainz(System.Uri contact);
+
+  public ListenBrainz(string contact);
+
+  public ListenBrainz(string application, System.Version version);
+
+  public ListenBrainz(string application, System.Version version, System.Uri contact);
+
+  public ListenBrainz(string application, System.Version version, string contact);
+
+  public ListenBrainz(string application, string version);
+
+  public ListenBrainz(string application, string version, System.Uri contact);
+
+  public ListenBrainz(string application, string version, string contact);
+
+  public void Close();
+
+  public sealed override void Dispose();
+
+  protected override void Finalize();
+
+  public MetaBrainz.ListenBrainz.Interfaces.IUserArtistMap? GetArtistMap(string user, StatisticsRange? range = default, bool forceRecalculation = false);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IUserArtistMap?> GetArtistMapAsync(string user, StatisticsRange? range = default, bool forceRecalculation = false, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.ISiteArtistStatistics? GetArtistStatistics(int? count = default, int? offset = default, StatisticsRange? range = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IUserArtistStatistics? GetArtistStatistics(string user, int? count = default, int? offset = default, StatisticsRange? range = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.ISiteArtistStatistics?> GetArtistStatisticsAsync(int? count = default, int? offset = default, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IUserArtistStatistics?> GetArtistStatisticsAsync(string user, int? count = default, int? offset = default, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IUserDailyActivity? GetDailyActivity(string user, StatisticsRange? range = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IUserDailyActivity?> GetDailyActivityAsync(string user, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.ILatestImport GetLatestImport(string user);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.ILatestImport> GetLatestImportAsync(string user, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IListenCount GetListenCount(string user);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IListenCount> GetListenCountAsync(string user, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IUserListeningActivity? GetListeningActivity(string user, StatisticsRange? range = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IUserListeningActivity?> GetListeningActivityAsync(string user, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IFetchedListens GetListens(string user, int? count = default, int? timeRange = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IFetchedListens GetListensAfter(string user, System.DateTimeOffset after, int? count = default, int? timeRange = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IFetchedListens GetListensAfter(string user, long after, int? count = default, int? timeRange = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IFetchedListens> GetListensAfterAsync(string user, System.DateTimeOffset after, int? count = default, int? timeRange = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IFetchedListens> GetListensAfterAsync(string user, long after, int? count = default, int? timeRange = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IFetchedListens> GetListensAsync(string user, int? count = default, int? timeRange = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IFetchedListens GetListensBefore(string user, System.DateTimeOffset before, int? count = default, int? timeRange = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IFetchedListens GetListensBefore(string user, long before, int? count = default, int? timeRange = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IFetchedListens> GetListensBeforeAsync(string user, System.DateTimeOffset before, int? count = default, int? timeRange = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IFetchedListens> GetListensBeforeAsync(string user, long before, int? count = default, int? timeRange = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IFetchedListens GetListensBetween(string user, System.DateTimeOffset after, System.DateTimeOffset before, int? count = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IFetchedListens GetListensBetween(string user, long after, long before, int? count = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IFetchedListens> GetListensBetweenAsync(string user, System.DateTimeOffset after, System.DateTimeOffset before, int? count = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IFetchedListens> GetListensBetweenAsync(string user, long after, long before, int? count = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IPlayingNow GetPlayingNow(string user);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IPlayingNow> GetPlayingNowAsync(string user, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IRecentListens GetRecentListens(System.Collections.Generic.IEnumerable<string> users);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IRecentListens GetRecentListens(int limit, System.Collections.Generic.IEnumerable<string> users);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IRecentListens GetRecentListens(int limit, params string[] users);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IRecentListens GetRecentListens(params string[] users);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IRecentListens> GetRecentListensAsync(System.Collections.Generic.IEnumerable<string> users, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IRecentListens> GetRecentListensAsync(System.Threading.CancellationToken cancellationToken, params string[] users);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IRecentListens> GetRecentListensAsync(int limit, System.Collections.Generic.IEnumerable<string> users, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IRecentListens> GetRecentListensAsync(int limit, System.Threading.CancellationToken cancellationToken, params string[] users);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IRecentListens> GetRecentListensAsync(int limit, params string[] users);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IRecentListens> GetRecentListensAsync(params string[] users);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IUserRecordingStatistics? GetRecordingStatistics(string user, int? count = default, int? offset = default, StatisticsRange? range = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IUserRecordingStatistics?> GetRecordingStatisticsAsync(string user, int? count = default, int? offset = default, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.IUserReleaseStatistics? GetReleaseStatistics(string user, int? count = default, int? offset = default, StatisticsRange? range = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IUserReleaseStatistics?> GetReleaseStatisticsAsync(string user, int? count = default, int? offset = default, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public void ImportListens(params MetaBrainz.ListenBrainz.Interfaces.ISubmittedListen[] listens);
+
+  public void ImportListens(System.Collections.Generic.IEnumerable<MetaBrainz.ListenBrainz.Interfaces.ISubmittedListen> listens);
+
+  public System.Threading.Tasks.Task ImportListensAsync(params MetaBrainz.ListenBrainz.Interfaces.ISubmittedListen[] listens);
+
+  public System.Threading.Tasks.Task ImportListensAsync(System.Collections.Generic.IAsyncEnumerable<MetaBrainz.ListenBrainz.Interfaces.ISubmittedListen> listens, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task ImportListensAsync(System.Collections.Generic.IEnumerable<MetaBrainz.ListenBrainz.Interfaces.ISubmittedListen> listens, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task ImportListensAsync(System.Threading.CancellationToken cancellationToken, params MetaBrainz.ListenBrainz.Interfaces.ISubmittedListen[] listens);
+
+  public void SetLatestImport(string user, System.DateTimeOffset timestamp);
+
+  public void SetLatestImport(string user, long timestamp);
+
+  public System.Threading.Tasks.Task SetLatestImportAsync(string user, System.DateTimeOffset timestamp, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task SetLatestImportAsync(string user, long timestamp, System.Threading.CancellationToken cancellationToken = default);
+
+  public void SetNowPlaying(MetaBrainz.ListenBrainz.Interfaces.ISubmittedListenData listen);
+
+  public void SetNowPlaying(string track, string artist, string? release = null);
+
+  public System.Threading.Tasks.Task SetNowPlayingAsync(MetaBrainz.ListenBrainz.Interfaces.ISubmittedListenData listen, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task SetNowPlayingAsync(string track, string artist, string? release = null, System.Threading.CancellationToken cancellationToken = default);
+
+  public void SubmitSingleListen(MetaBrainz.ListenBrainz.Interfaces.ISubmittedListen listen);
+
+  public void SubmitSingleListen(System.DateTimeOffset timestamp, string track, string artist, string? release = null);
+
+  public void SubmitSingleListen(long timestamp, string track, string artist, string? release = null);
+
+  public void SubmitSingleListen(string track, string artist, string? release = null);
+
+  public System.Threading.Tasks.Task SubmitSingleListenAsync(MetaBrainz.ListenBrainz.Interfaces.ISubmittedListen listen, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task SubmitSingleListenAsync(System.DateTimeOffset timestamp, string track, string artist, string? release = null, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task SubmitSingleListenAsync(long timestamp, string track, string artist, string? release = null, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task SubmitSingleListenAsync(string track, string artist, string? release = null, System.Threading.CancellationToken cancellationToken = default);
+
+  public MetaBrainz.ListenBrainz.Interfaces.ITokenValidationResult ValidateToken(string token);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.ITokenValidationResult> ValidateTokenAsync(string token, System.Threading.CancellationToken cancellationToken = default);
+
+}
+```
+
+### Type: QueryException
+
+```cs
+public sealed class QueryException : System.Exception {
+
+  public readonly System.Net.HttpStatusCode Code;
+
+  public readonly string? Reason;
+
+  public QueryException(System.Net.HttpStatusCode code, string? reason = null, string? message = null, System.Exception? cause = null);
+
+}
+```
+
+### Type: StatisticsRange
+
+```cs
+public enum StatisticsRange {
+
+  AllTime = 0,
+  Month = 2,
+  Unknown = 4,
+  Week = 1,
+  Year = 3,
+
+}
+```
+
+## Namespace: MetaBrainz.ListenBrainz.Interfaces
+
+### Type: IAdditionalInfo
+
+```cs
+public interface IAdditionalInfo {
+
+  System.Collections.Generic.IReadOnlyDictionary<string, object?> AllFields {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<System.Guid?>? ArtistIds {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<string?>? ArtistNames {
+    public abstract get;
+  }
+
+  int? DiscNumber {
+    public abstract get;
+  }
+
+  System.TimeSpan? Duration {
+    public abstract get;
+  }
+
+  System.Guid? ImportedArtistId {
+    public abstract get;
+  }
+
+  System.Guid? ImportedReleaseId {
+    public abstract get;
+  }
+
+  string? Isrc {
+    public abstract get;
+  }
+
+  string? ListeningFrom {
+    public abstract get;
+  }
+
+  string? MediaPlayer {
+    public abstract get;
+  }
+
+  string? MediaPlayerVersion {
+    public abstract get;
+  }
+
+  System.Guid? MessyArtistId {
+    public abstract get;
+  }
+
+  System.Guid? MessyRecordingId {
+    public abstract get;
+  }
+
+  System.Guid? MessyReleaseId {
+    public abstract get;
+  }
+
+  string? MusicService {
+    public abstract get;
+  }
+
+  string? MusicServiceName {
+    public abstract get;
+  }
+
+  System.Uri? OriginUrl {
+    public abstract get;
+  }
+
+  System.Guid? RecordingId {
+    public abstract get;
+  }
+
+  string? ReleaseArtistName {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<string?>? ReleaseArtistNames {
+    public abstract get;
+  }
+
+  System.Guid? ReleaseGroupId {
+    public abstract get;
+  }
+
+  System.Guid? ReleaseId {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<System.Uri?>? SpotifyAlbumArtistIds {
+    public abstract get;
+  }
+
+  System.Uri? SpotifyAlbumId {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<System.Uri?>? SpotifyArtistIds {
+    public abstract get;
+  }
+
+  System.Uri? SpotifyId {
+    public abstract get;
+  }
+
+  string? SubmissionClient {
+    public abstract get;
+  }
+
+  string? SubmissionClientVersion {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<string?>? Tags {
+    public abstract get;
+  }
+
+  System.Guid? TrackId {
+    public abstract get;
+  }
+
+  int? TrackNumber {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<System.Guid?>? WorkIds {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IArtistCountryInfo
+
+```cs
+public interface IArtistCountryInfo {
+
+  int ArtistCount {
+    public abstract get;
+  }
+
+  string Country {
+    public abstract get;
+  }
+
+  int ListenCount {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IArtistInfo
+
+```cs
+public interface IArtistInfo : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.Collections.Generic.IReadOnlyList<System.Guid>? Ids {
+    public abstract get;
+  }
+
+  int ListenCount {
+    public abstract get;
+  }
+
+  System.Guid? MessyId {
+    public abstract get;
+  }
+
+  string Name {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IArtistStatistics
+
+```cs
+public interface IArtistStatistics {
+
+  System.Collections.Generic.IReadOnlyList<IArtistInfo>? Artists {
+    public abstract get;
+  }
+
+  int Count {
+    public abstract get;
+  }
+
+  int Offset {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IDailyActivity
+
+```cs
+public interface IDailyActivity : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.Collections.Generic.IReadOnlyList<IHourlyActivity>? Friday {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IHourlyActivity>? Monday {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IHourlyActivity>? Saturday {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IHourlyActivity>? Sunday {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IHourlyActivity>? Thursday {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IHourlyActivity>? Tuesday {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IHourlyActivity>? Wednesday {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IFetchedListens
+
+```cs
+public interface IFetchedListens : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.Collections.Generic.IReadOnlyList<IListen> Listens {
+    public abstract get;
+  }
+
+  System.DateTimeOffset Timestamp {
+    public abstract get;
+  }
+
+  long UnixTimestamp {
+    public abstract get;
+  }
+
+  string User {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IHourlyActivity
+
+```cs
+public interface IHourlyActivity : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  int Hour {
+    public abstract get;
+  }
+
+  int ListenCount {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: ILatestImport
+
+```cs
+public interface ILatestImport : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.DateTimeOffset? Timestamp {
+    public abstract get;
+  }
+
+  long? UnixTimestamp {
+    public abstract get;
+  }
+
+  string? User {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IListen
+
+```cs
+public interface IListen : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  string InsertedAt {
+    public abstract get;
+  }
+
+  System.Guid MessyRecordingId {
+    public abstract get;
+  }
+
+  System.DateTimeOffset Timestamp {
+    public abstract get;
+  }
+
+  ITrackInfo Track {
+    public abstract get;
+  }
+
+  long UnixTimestamp {
+    public abstract get;
+  }
+
+  string User {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IListenCount
+
+```cs
+public interface IListenCount : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  long Count {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IListenTimeRange
+
+```cs
+public interface IListenTimeRange {
+
+  string Description {
+    public abstract get;
+  }
+
+  int ListenCount {
+    public abstract get;
+  }
+
+  System.DateTimeOffset? RangeEnd {
+    public abstract get;
+  }
+
+  System.DateTimeOffset? RangeStart {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IMusicBrainzIdMappings
+
+```cs
+public interface IMusicBrainzIdMappings {
+
+  System.Collections.Generic.IReadOnlyList<System.Guid>? ArtistIds {
+    public abstract get;
+  }
+
+  System.Guid? RecordingId {
+    public abstract get;
+  }
+
+  System.Guid? ReleaseId {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IPlayingNow
+
+```cs
+public interface IPlayingNow : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  IPlayingTrack? Track {
+    public abstract get;
+  }
+
+  string User {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IPlayingTrack
+
+```cs
+public interface IPlayingTrack : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  ITrackInfo Info {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IRecentListens
+
+```cs
+public interface IRecentListens : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.Collections.Generic.IReadOnlyList<IListen> Listens {
+    public abstract get;
+  }
+
+  string UserList {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IRecordingInfo
+
+```cs
+public interface IRecordingInfo {
+
+  System.Collections.Generic.IReadOnlyList<System.Guid>? ArtistIds {
+    public abstract get;
+  }
+
+  System.Guid? ArtistMessyId {
+    public abstract get;
+  }
+
+  string? ArtistName {
+    public abstract get;
+  }
+
+  System.Guid? Id {
+    public abstract get;
+  }
+
+  int ListenCount {
+    public abstract get;
+  }
+
+  System.Guid? MessyId {
+    public abstract get;
+  }
+
+  string Name {
+    public abstract get;
+  }
+
+  System.Guid? ReleaseId {
+    public abstract get;
+  }
+
+  System.Guid? ReleaseMessyId {
+    public abstract get;
+  }
+
+  string? ReleaseName {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IReleaseInfo
+
+```cs
+public interface IReleaseInfo {
+
+  System.Collections.Generic.IReadOnlyList<System.Guid>? ArtistIds {
+    public abstract get;
+  }
+
+  System.Guid? ArtistMessyId {
+    public abstract get;
+  }
+
+  string? ArtistName {
+    public abstract get;
+  }
+
+  System.Guid? Id {
+    public abstract get;
+  }
+
+  int ListenCount {
+    public abstract get;
+  }
+
+  System.Guid? MessyId {
+    public abstract get;
+  }
+
+  string Name {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: ISiteArtistStatistics
+
+```cs
+public interface ISiteArtistStatistics : IArtistStatistics, IStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
+
+}
+```
+
+### Type: IStatistics
+
+```cs
+public interface IStatistics : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.DateTimeOffset LastUpdated {
+    public abstract get;
+  }
+
+  System.DateTimeOffset? NewestListen {
+    public abstract get;
+  }
+
+  System.DateTimeOffset? OldestListen {
+    public abstract get;
+  }
+
+  MetaBrainz.ListenBrainz.StatisticsRange Range {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: ISubmittedListen
+
+```cs
+public interface ISubmittedListen : ISubmittedListenData {
+
+  System.DateTimeOffset Timestamp {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: ISubmittedListenData
+
+```cs
+public interface ISubmittedListenData {
+
+  ISubmittedTrackInfo Track {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: ISubmittedTrackInfo
+
+```cs
+public interface ISubmittedTrackInfo {
+
+  System.Collections.Generic.IReadOnlyDictionary<string, object?>? AdditionalInfo {
+    public abstract get;
+  }
+
+  string Artist {
+    public abstract get;
+  }
+
+  string Name {
+    public abstract get;
+  }
+
+  string? Release {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: ITokenValidationResult
+
+```cs
+public interface ITokenValidationResult {
+
+  System.Net.HttpStatusCode Code {
+    public abstract get;
+  }
+
+  string Message {
+    public abstract get;
+  }
+
+  string? User {
+    public abstract get;
+  }
+
+  bool? Valid {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: ITrackInfo
+
+```cs
+public interface ITrackInfo : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  IAdditionalInfo AdditionalInfo {
+    public abstract get;
+  }
+
+  string Artist {
+    public abstract get;
+  }
+
+  IMusicBrainzIdMappings? MusicBrainzIdMappings {
+    public abstract get;
+  }
+
+  string Name {
+    public abstract get;
+  }
+
+  string? Release {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IUserArtistMap
+
+```cs
+public interface IUserArtistMap : IStatistics, IUserStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.Collections.Generic.IReadOnlyList<IArtistCountryInfo>? Countries {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IUserArtistStatistics
+
+```cs
+public interface IUserArtistStatistics : IArtistStatistics, IStatistics, IUserStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
+
+  int TotalCount {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IUserDailyActivity
+
+```cs
+public interface IUserDailyActivity : IStatistics, IUserStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
+
+  IDailyActivity? Activity {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IUserListeningActivity
+
+```cs
+public interface IUserListeningActivity : IStatistics, IUserStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.Collections.Generic.IReadOnlyList<IListenTimeRange>? Activity {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IUserRecordingStatistics
+
+```cs
+public interface IUserRecordingStatistics : IStatistics, IUserStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
+
+  int? Offset {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IRecordingInfo>? Recordings {
+    public abstract get;
+  }
+
+  int? TotalCount {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IUserReleaseStatistics
+
+```cs
+public interface IUserReleaseStatistics : IStatistics, IUserStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
+
+  int? Offset {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IReleaseInfo>? Releases {
+    public abstract get;
+  }
+
+  int? TotalCount {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IUserStatistics
+
+```cs
+public interface IUserStatistics : IStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
+
+  string User {
+    public abstract get;
+  }
+
+}
+```
+
+## Namespace: MetaBrainz.ListenBrainz.Objects
+
+### Type: SubmittedListen
+
+```cs
+public class SubmittedListen : SubmittedListenData, MetaBrainz.ListenBrainz.Interfaces.ISubmittedListen, MetaBrainz.ListenBrainz.Interfaces.ISubmittedListenData {
+
+  System.DateTimeOffset Timestamp {
+    public sealed override get;
+    public set;
+  }
+
+  public SubmittedListen(System.DateTimeOffset timestamp, string track, string artist, string? release = null);
+
+  public SubmittedListen(long timestamp, string track, string artist, string? release = null);
+
+  public SubmittedListen(string track, string artist, string? release = null);
+
+}
+```
+
+### Type: SubmittedListenData
+
+```cs
+public class SubmittedListenData : MetaBrainz.ListenBrainz.Interfaces.ISubmittedListenData {
+
+  public readonly SubmittedTrackInfo Track;
+
+  public SubmittedListenData(string track, string artist, string? release = null);
+
+}
+```
+
+### Type: SubmittedTrackInfo
+
+```cs
+public class SubmittedTrackInfo : MetaBrainz.ListenBrainz.Interfaces.ISubmittedTrackInfo {
+
+  System.Collections.Generic.Dictionary<string, object?>? AdditionalInfo {
+    public get;
+    public set;
+  }
+
+  string Artist {
+    public sealed override get;
+    public set;
+  }
+
+  string Name {
+    public sealed override get;
+    public set;
+  }
+
+  string? Release {
+    public sealed override get;
+    public set;
+  }
+
+  public SubmittedTrackInfo(string name, string artist, string? release = null);
+
+}
+```


### PR DESCRIPTION
- update GitHub Actions
- drop AppVeyor builds
  - instead, use GitHub Actions for CI
- enable Dependabot for GitHub Actions and configure labels for it
- set `AssemblyIsComVisible` to `false` in the project file
  - allows dropping the `AssemblyInfo.cs` file
- add "public API" reference files
- align copyright years between license file and project
- target `net6.0` and `net8.0` only
  - dropped the obsolete `ISerializable` code from `QueryException`