### PR TITLE
Use a trace source for debug output

### DIFF
--- a/MetaBrainz.ListenBrainz/ListenBrainz.cs
+++ b/MetaBrainz.ListenBrainz/ListenBrainz.cs
@@ -49,7 +49,7 @@ public sealed class ListenBrainz : IDisposable {
   public const int MaxTimeRange = 73;
 
   /// <summary>The URL included in the user agent for requests as part of this library's information.</summary>
-  public const string UserAgentUrl = "https://github.com/Zastai/ListenBrainz";
+  public const string UserAgentUrl = "https://github.com/Zastai/MetaBrainz.ListenBrainz";
 
   /// <summary>The root location of the web service.</summary>
   public const string WebServiceRoot = "/1/";

--- a/MetaBrainz.ListenBrainz/ListenBrainz.cs
+++ b/MetaBrainz.ListenBrainz/ListenBrainz.cs
@@ -80,6 +80,9 @@ public sealed class ListenBrainz : IDisposable {
   /// <summary>The default user token to use for requests; used as initial value for <see cref="UserToken"/>.</summary>
   public static string? DefaultUserToken { get; set; }
 
+  /// <summary>The trace source (named 'MetaBrainz.ListenBrainz') used by this class.</summary>
+  public static readonly TraceSource TraceSource = new("MetaBrainz.ListenBrainz", SourceLevels.Off);
+
   #endregion
 
   #region Constructors
@@ -1672,7 +1675,8 @@ public sealed class ListenBrainz : IDisposable {
                                                               IDictionary<string, string>? options,
                                                               CancellationToken cancellationToken = default) {
     var requestUri = address + ListenBrainz.QueryString(options);
-    Debug.Print($"[{DateTime.UtcNow}] WEB SERVICE REQUEST: {method.Method} {this.BaseUri}{requestUri}");
+    var ts = ListenBrainz.TraceSource;
+    ts.TraceEvent(TraceEventType.Verbose, 1, "WEB SERVICE REQUEST: {0} {1}{2}", method.Method, this.BaseUri, requestUri);
     var client = this.Client;
     HttpRequestMessage request;
     switch (method.Method) {
@@ -1685,8 +1689,8 @@ public sealed class ListenBrainz : IDisposable {
         break;
       }
       case "POST": {
-        if (body is not null) {
-          Debug.Print($"[{DateTime.UtcNow}] => BODY: {body}");
+        if (body is not null && ts.Switch.ShouldTrace(TraceEventType.Verbose)) {
+          ts.TraceEvent(TraceEventType.Verbose, 2, "BODY: {0}", TextUtils.FormatMultiLine(body));
         }
         request = new HttpRequestMessage(HttpMethod.Post, requestUri) {
           Content = new StringContent(body ?? "", Encoding.UTF8, "application/json"),
@@ -1700,11 +1704,13 @@ public sealed class ListenBrainz : IDisposable {
         throw new HttpError(HttpStatusCode.MethodNotAllowed, $"Unsupported method: {method}");
     }
     var response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
-    Debug.Print($"[{DateTime.UtcNow}] => RESPONSE: {(int) response.StatusCode}/{response.StatusCode} '{response.ReasonPhrase}' " +
-                $"(v{response.Version})");
-    Debug.Print($"[{DateTime.UtcNow}] => HEADERS: {TextUtils.FormatMultiLine(response.Headers.ToString())}");
-    Debug.Print($"[{DateTime.UtcNow}] => CONTENT: {response.Content.Headers.ContentType}, " +
-                $"{response.Content.Headers.ContentLength ?? 0} byte(s))");
+    if (ts.Switch.ShouldTrace(TraceEventType.Verbose)) {
+      ts.TraceEvent(TraceEventType.Verbose, 3, "RESPONSE: {0:D}/{0} '{1}' (v{2})", response.StatusCode, response.ReasonPhrase,
+                    response.Version);
+      ts.TraceEvent(TraceEventType.Verbose, 4, "HEADERS: {0}", TextUtils.FormatMultiLine(response.Headers.ToString()));
+      var headers = response.Content.Headers;
+      ts.TraceEvent(TraceEventType.Verbose, 5, "CONTENT ({0}): {1} bytes", headers.ContentType, headers.ContentLength ?? 0);
+    }
     var rateLimitInfo = new RateLimitInfo(response.Headers);
     this._rateLimitLock.EnterWriteLock();
     try {
@@ -1727,18 +1733,18 @@ public sealed class ListenBrainz : IDisposable {
           }
         }
         catch (Exception e) {
-          Debug.Print($"[{DateTime.UtcNow}] => FAILED TO PARSE ERROR RESPONSE CONTENT AS JSON: {e.Message}");
+          ts.TraceEvent(TraceEventType.Verbose, 6, "FAILED TO PARSE ERROR RESPONSE CONTENT AS JSON: {0}", e.Message);
           ei = null;
         }
         if (ei is not null) {
           var reason = error.Reason;
           if (ei.Code != (int) response.StatusCode) {
-            Debug.Print($"[{DateTime.UtcNow}] => ERROR CODE ({ei.Code}) DOES NOT MATCH HTTP STATUS CODE!");
+            ts.TraceEvent(TraceEventType.Verbose, 7, "ERROR CODE ({0}) DOES NOT MATCH HTTP STATUS CODE", ei.Code);
             reason = "Error";
           }
           if (ei.UnhandledProperties is not null) {
             foreach (var prop in ei.UnhandledProperties) {
-              Debug.Print($"[{DateTime.UtcNow}] => UNEXPECTED ERROR PROPERTY: {prop.Key} -> {prop.Value}");
+              ts.TraceEvent(TraceEventType.Verbose, 8, "UNEXPECTED ERROR PROPERTY: {0} -> {1}", prop.Key, prop.Value);
             }
           }
           throw new HttpError((HttpStatusCode) ei.Code, reason, response.Version, ei.Error, error);
@@ -1755,10 +1761,13 @@ public sealed class ListenBrainz : IDisposable {
   private async Task PostAsync(string address, string body, IDictionary<string, string>? options,
                                CancellationToken cancellationToken = default) {
     var response = await this.PerformRequestAsync(address, HttpMethod.Post, body, options, cancellationToken).ConfigureAwait(false);
-#if DEBUG
-    var content = await response.GetStringContentAsync(cancellationToken).ConfigureAwait(false);
-    Debug.Print($"[{DateTime.UtcNow}] => RESPONSE TEXT: {TextUtils.FormatMultiLine(content)}");
-#endif
+    if (ListenBrainz.TraceSource.Switch.ShouldTrace(TraceEventType.Verbose)) {
+      var content = await response.GetStringContentAsync(cancellationToken).ConfigureAwait(false);
+      if (content.Length > 0) {
+        ListenBrainz.TraceSource.TraceEvent(TraceEventType.Verbose, 9, "POST RETURNED A MESSAGE: {0}",
+                                            TextUtils.FormatMultiLine(content));
+      }
+    }
   }
 
   #endregion

--- a/README.md
+++ b/README.md
@@ -18,6 +18,73 @@ This is a library providing access to the
 [last-fm]: https://www.last.fm
 [libre-fm]: https://libre.fm
 
+## Debugging
+
+The `ListenBrainz` class provides a `TraceSource` that can be used to
+configure debug output; its name is `MetaBrainz.ListenBrainz`.
+
+### Configuration
+
+#### In Code
+
+In code, you can enable tracing like follows:
+
+```cs
+// Use the default switch, turning it on.
+ListenBrainz.TraceSource.Switch.Level = SourceLevels.All;
+
+// Alternatively, use your own switch so multiple things can be
+// enabled/disabled at the same time.
+var mySwitch = new TraceSwitch("MyAppDebugSwitch", "All");
+ListenBrainz.TraceSource.Switch = mySwitch;
+
+// By default, there is a single listener that writes trace events to
+// the debug output (typically only seen in an IDE's debugger). You can
+// add (and remove) listeners as desired.
+var listener = new ConsoleTraceListener {
+  Name = "MyAppConsole",
+  TraceOutputOptions = TraceOptions.DateTime | TraceOptions.ProcessId,
+};
+ListenBrainz.TraceSource.Listeners.Clear();
+ListenBrainz.TraceSource.Listeners.Add(listener);
+```
+
+#### In Configuration
+
+Starting from .NET 7 your application can also be set up to read tracing
+configuration from the application configuration file. To do so, the
+application needs to add the following to its startup code:
+
+```cs
+System.Diagnostics.TraceConfiguration.Register();
+```
+
+(Provided by the `System.Configuration.ConfigurationManager` package.)
+
+The application config file can then have a `system.diagnostics` section
+where sources, switches and listeners can be configured.
+
+```xml
+<configuration>
+  <system.diagnostics>
+    <sharedListeners>
+      <add name="console" type="System.Diagnostics.ConsoleTraceListener" traceOutputOptions="DateTime,ProcessId" />
+    </sharedListeners>
+    <sources>
+      <source name="MetaBrainz.ListenBrainz" switchName="MetaBrainz.ListenBrainz">
+        <listeners>
+          <add name="console" />
+          <add name="lb-log" type="System.Diagnostics.TextWriterTraceListener" initializeData="lb.log" />
+        </listeners>
+      </source>
+    </sources>
+    <switches>
+      <add name="MetaBrainz.ListenBrainz" value="All" />
+    </switches>
+  </system.diagnostics>
+</configuration>
+```
+
 ## Release Notes
 
 These are available [on GitHub][release-notes].

--- a/public-api/MetaBrainz.ListenBrainz.net6.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net6.0.cs.md
@@ -28,6 +28,8 @@ public sealed class ListenBrainz : System.IDisposable {
 
   public const int MaxTimeRange = 73;
 
+  public static readonly System.Diagnostics.TraceSource TraceSource;
+
   public const string UserAgentUrl = "https://github.com/Zastai/MetaBrainz.ListenBrainz";
 
   public const string WebServiceRoot = "/1/";

--- a/public-api/MetaBrainz.ListenBrainz.net6.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net6.0.cs.md
@@ -28,7 +28,7 @@ public sealed class ListenBrainz : System.IDisposable {
 
   public const int MaxTimeRange = 73;
 
-  public const string UserAgentUrl = "https://github.com/Zastai/ListenBrainz";
+  public const string UserAgentUrl = "https://github.com/Zastai/MetaBrainz.ListenBrainz";
 
   public const string WebServiceRoot = "/1/";
 

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -28,6 +28,8 @@ public sealed class ListenBrainz : System.IDisposable {
 
   public const int MaxTimeRange = 73;
 
+  public static readonly System.Diagnostics.TraceSource TraceSource;
+
   public const string UserAgentUrl = "https://github.com/Zastai/MetaBrainz.ListenBrainz";
 
   public const string WebServiceRoot = "/1/";

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -28,7 +28,7 @@ public sealed class ListenBrainz : System.IDisposable {
 
   public const int MaxTimeRange = 73;
 
-  public const string UserAgentUrl = "https://github.com/Zastai/ListenBrainz";
+  public const string UserAgentUrl = "https://github.com/Zastai/MetaBrainz.ListenBrainz";
 
   public const string WebServiceRoot = "/1/";
 


### PR DESCRIPTION
This replaces all uses of `Debug.Print` (and conditional compilation for DEBUG builds) with output using a trace source.

Added section to the README describing how this can be configured.

This also fixes the UserAgent URL.