### PR TITLE
Fix the `inserted_at` field on listens

### DIFF
--- a/MetaBrainz.ListenBrainz/Interfaces/IListen.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IListen.cs
@@ -11,8 +11,8 @@ namespace MetaBrainz.ListenBrainz.Interfaces;
 [PublicAPI]
 public interface IListen : IJsonBasedObject {
 
-  /// <summary>The timestamp at which the listen information was inserted in the database, in human-readable format.</summary>
-  string InsertedAt { get; }
+  /// <summary>The timestamp at which the listen information was inserted in the database.</summary>
+  DateTimeOffset InsertedAt { get; }
 
   /// <summary>The MessyBrainz ID for the recording that was listened to.</summary>
   Guid MessyRecordingId { get; }

--- a/MetaBrainz.ListenBrainz/Json/Readers/ListenReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ListenReader.cs
@@ -14,7 +14,7 @@ internal class ListenReader : ObjectReader<Listen> {
   public static readonly ListenReader Instance = new();
 
   protected override Listen ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
-    string? inserted = null;
+    long? inserted = null;
     Guid? msid = null;
     ITrackInfo? track = null;
     string? user = null;
@@ -26,7 +26,7 @@ internal class ListenReader : ObjectReader<Listen> {
         reader.Read();
         switch (prop) {
           case "inserted_at":
-            inserted = reader.GetString();
+            inserted = reader.GetInt64();
             break;
           case "listened_at":
             ts = reader.GetInt64();
@@ -66,7 +66,7 @@ internal class ListenReader : ObjectReader<Listen> {
     if (ts is null) {
       throw new JsonException("Expected listened-at timestamp not found or null.");
     }
-    return new Listen(inserted, msid.Value, ts.Value, track, user) {
+    return new Listen(inserted.Value, msid.Value, ts.Value, track, user) {
       UnhandledProperties = rest
     };
   }

--- a/MetaBrainz.ListenBrainz/Objects/Listen.cs
+++ b/MetaBrainz.ListenBrainz/Objects/Listen.cs
@@ -10,8 +10,8 @@ namespace MetaBrainz.ListenBrainz.Objects;
 [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
 internal sealed class Listen : JsonBasedObject, IListen {
 
-  public Listen(string inserted, Guid msid, long timestamp, ITrackInfo track, string user) {
-    this.InsertedAt = inserted;
+  public Listen(long inserted, Guid msid, long timestamp, ITrackInfo track, string user) {
+    this.InsertedAt = DateTimeOffset.FromUnixTimeSeconds(inserted);
     this.MessyRecordingId = msid;
     this.Timestamp = DateTimeOffset.FromUnixTimeSeconds(timestamp);
     this.Track = track;
@@ -19,7 +19,7 @@ internal sealed class Listen : JsonBasedObject, IListen {
     this.User = user;
   }
 
-  public string InsertedAt { get; }
+  public DateTimeOffset InsertedAt { get; }
 
   public Guid MessyRecordingId { get; }
 

--- a/public-api/MetaBrainz.ListenBrainz.net6.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net6.0.cs.md
@@ -586,7 +586,7 @@ public interface ILatestImport : MetaBrainz.Common.Json.IJsonBasedObject {
 ```cs
 public interface IListen : MetaBrainz.Common.Json.IJsonBasedObject {
 
-  string InsertedAt {
+  System.DateTimeOffset InsertedAt {
     public abstract get;
   }
 

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -586,7 +586,7 @@ public interface ILatestImport : MetaBrainz.Common.Json.IJsonBasedObject {
 ```cs
 public interface IListen : MetaBrainz.Common.Json.IJsonBasedObject {
 
-  string InsertedAt {
+  System.DateTimeOffset InsertedAt {
     public abstract get;
   }
 


### PR DESCRIPTION
This resolves a deserialization error. Not that this also changes `IListen.InsertedAt` from a `string` to a `DateTimeOffset`.

Fixes #46.