### PR TITLE
Update the mappings to match current API results

### DIFF
--- a/MetaBrainz.ListenBrainz/Interfaces/IArtistCountryInfo.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IArtistCountryInfo.cs
@@ -1,13 +1,18 @@
+using System.Collections.Generic;
+
 using JetBrains.Annotations;
 
 namespace MetaBrainz.ListenBrainz.Interfaces;
 
-/// <summary>Information about listens for artists of a particular country.</summary>
+/// <summary>Information about listens for artists from a particular country.</summary>
 [PublicAPI]
 public interface IArtistCountryInfo {
 
   /// <summary>The number of (distinct) artists from this country that were listened to.</summary>
   int ArtistCount { get; }
+
+  /// <summary>Information about the artists from this country that were listened to.</summary>
+  IReadOnlyList<IArtistInfo>? Artists { get; }
 
   /// <summary>The 3-letter country code (ISO 3166-1 alpha-3).</summary>
   string Country { get; }

--- a/MetaBrainz.ListenBrainz/Interfaces/IArtistCredit.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IArtistCredit.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+using JetBrains.Annotations;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>An entry in an artist credit taken from the MusicBrainz database.</summary>
+[PublicAPI]
+public interface IArtistCredit {
+
+  /// <summary>The name specified for the artist in the credit.</summary>
+  string CreditedName { get; }
+
+  /// <summary>The MusicBrainz IDs for the artist.</summary>
+  Guid Id { get; }
+
+  /// <summary>
+  /// The phrase used to connect this entry to the next one in the credit, or to end the credit if this is the last entry.
+  /// </summary>
+  string? JoinPhrase { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/IArtistInfo.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IArtistInfo.cs
@@ -11,7 +11,13 @@ namespace MetaBrainz.ListenBrainz.Interfaces;
 [PublicAPI]
 public interface IArtistInfo : IJsonBasedObject {
 
+  /// <summary>The MusicBrainz ID for the artist, if available.</summary>
+  Guid? Id { get; }
+
   /// <summary>The MusicBrainz IDs for the artist, if available.</summary>
+  /// <remarks>
+  /// This may be obsolete; the current API only ever seems to return a single ID, which will be available in <see cref="Id"/>.
+  /// </remarks>
   IReadOnlyList<Guid>? Ids { get; }
 
   /// <summary>The number of times the artist's tracks were listened to.</summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/IFetchedListens.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IFetchedListens.cs
@@ -15,14 +15,19 @@ public interface IFetchedListens : IJsonBasedObject {
   /// <summary>The listens that were fetched.</summary>
   IReadOnlyList<IListen> Listens { get; }
 
-  /// <summary>The timestamp of the newest listen included in <see cref="Listens"/>.</summary>
-  DateTimeOffset Timestamp { get; }
+  /// <summary>The timestamp of the newest listen recorded for the user.</summary>
+  /// <remarks>
+  /// This looks at the entire dataset, not just the date range that may have been specified in the request. The listen(s) with this
+  /// timestamp will not necessarily be included in <see cref="Listens"/>.
+  /// </remarks>
+  DateTimeOffset Newest { get; }
 
-  /// <summary>
-  /// The timestamp of the newest listen included in <see cref="Listens"/>, expressed as the number of seconds since
-  /// <see cref="UnixTime.Epoch">the Unix time epoch</see>.
-  /// </summary>
-  long UnixTimestamp { get; }
+  /// <summary>The timestamp of the oldest listen recorded for the user.</summary>
+  /// <remarks>
+  /// This looks at the entire dataset, not just the date range that may have been specified in the request. The listen(s) with this
+  /// timestamp will not necessarily be included in <see cref="Listens"/>.
+  /// </remarks>
+  DateTimeOffset Oldest { get; }
 
   /// <summary>The MusicBrainz ID of the user for which the listens were fetched.</summary>
   string User { get; }

--- a/MetaBrainz.ListenBrainz/Interfaces/IListen.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IListen.cs
@@ -14,19 +14,14 @@ public interface IListen : IJsonBasedObject {
   /// <summary>The timestamp at which the listen information was inserted in the database.</summary>
   DateTimeOffset InsertedAt { get; }
 
+  /// <summary>The timestamp at which the listen occurred.</summary>
+  DateTimeOffset ListenedAt { get; }
+
   /// <summary>The MessyBrainz ID for the recording that was listened to.</summary>
   Guid MessyRecordingId { get; }
 
-  /// <summary>The timestamp at which the listen occurred.</summary>
-  DateTimeOffset Timestamp { get; }
-
   /// <summary>Information about the track that was listened to.</summary>
   ITrackInfo Track { get; }
-
-  /// <summary>
-  /// The timestamp for the listen, expressed as the number of seconds since <see cref="UnixTime.Epoch">the Unix time epoch</see>.
-  /// </summary>
-  long UnixTimestamp { get; }
 
   /// <summary>The MusicBrainz ID of the user who submitted the listen.</summary>
   string User { get; }

--- a/MetaBrainz.ListenBrainz/Interfaces/IMusicBrainzIdMappings.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IMusicBrainzIdMappings.cs
@@ -1,19 +1,34 @@
 using System;
 using System.Collections.Generic;
 
+using JetBrains.Annotations;
+
 namespace MetaBrainz.ListenBrainz.Interfaces;
 
 /// <summary>
 /// Mappings to MusicBrainz IDs as determined by ListenBrainz.<br/>
 /// There are similar fields in <see cref="IAdditionalInfo"/>, but those are values supplied at submission time by the client.
 /// </summary>
+[PublicAPI]
 public interface IMusicBrainzIdMappings {
 
   /// <summary>The MusicBrainz IDs for the track's artists.</summary>
   IReadOnlyList<Guid>? ArtistIds { get; }
 
+  /// <summary>The internal ID for the track's release in the CoverArt Archive.</summary>
+  long? CoverArtId { get; }
+
+  /// <summary>The MusicBrainz ID for the track's release in the CoverArt Archive.</summary>
+  Guid? CoverArtReleaseId { get; }
+
+  /// <summary>The MusicBrainz credits for the track's artists.</summary>
+  IReadOnlyList<IArtistCredit>? Credits { get; }
+
   /// <summary>The MusicBrainz ID for the track's recording.</summary>
   Guid? RecordingId { get; }
+
+  /// <summary>The name for the track's recording in the MusicBrainz database.</summary>
+  string? RecordingName { get; }
 
   /// <summary>The MusicBrainz ID for the track's release.</summary>
   Guid? ReleaseId { get; }

--- a/MetaBrainz.ListenBrainz/Interfaces/IRecordingInfo.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IRecordingInfo.cs
@@ -18,6 +18,15 @@ public interface IRecordingInfo {
   /// <summary>The recording's artist's name, if available.</summary>
   string? ArtistName { get; }
 
+  /// <summary>The internal ID for the recording's release in the CoverArt Archive.</summary>
+  long? CoverArtId { get; }
+
+  /// <summary>The MusicBrainz ID for the recording's release in the CoverArt Archive.</summary>
+  Guid? CoverArtReleaseId { get; }
+
+  /// <summary>The MusicBrainz credits for the recording's artists.</summary>
+  IReadOnlyList<IArtistCredit>? Credits { get; }
+
   /// <summary>The number of times the recording was listened to.</summary>
   int ListenCount { get; }
 

--- a/MetaBrainz.ListenBrainz/Interfaces/IReleaseInfo.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IReleaseInfo.cs
@@ -18,6 +18,15 @@ public interface IReleaseInfo {
   /// <summary>The release's artist's name, if available.</summary>
   string? ArtistName { get; }
 
+  /// <summary>The internal ID for the track's release in the CoverArt Archive.</summary>
+  long? CoverArtId { get; }
+
+  /// <summary>The MusicBrainz ID for the track's release in the CoverArt Archive.</summary>
+  Guid? CoverArtReleaseId { get; }
+
+  /// <summary>The MusicBrainz credits for the track's artists.</summary>
+  IReadOnlyList<IArtistCredit>? Credits { get; }
+
   /// <summary>The MusicBrainz ID for the release, if available.</summary>
   Guid? Id { get; }
 

--- a/MetaBrainz.ListenBrainz/Json/Readers/ArtistCountryInfoReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ArtistCountryInfoReader.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 
 using MetaBrainz.Common.Json;
 using MetaBrainz.Common.Json.Converters;
+using MetaBrainz.ListenBrainz.Interfaces;
 using MetaBrainz.ListenBrainz.Objects;
 
 namespace MetaBrainz.ListenBrainz.Json.Readers;
@@ -14,6 +15,7 @@ internal class ArtistCountryInfoReader : ObjectReader<ArtistCountryInfo> {
 
   protected override ArtistCountryInfo ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
     int? artistCount = null;
+    IReadOnlyList<IArtistInfo>? artists = null;
     int? listenCount = null;
     string? country = null;
     Dictionary<string, object?>? rest = null;
@@ -22,6 +24,9 @@ internal class ArtistCountryInfoReader : ObjectReader<ArtistCountryInfo> {
       try {
         reader.Read();
         switch (prop) {
+          case "artists":
+            artists = reader.ReadList(ArtistInfoReader.Instance, options);
+            break;
           case "artist_count":
             artistCount = reader.GetInt32();
             break;
@@ -52,6 +57,7 @@ internal class ArtistCountryInfoReader : ObjectReader<ArtistCountryInfo> {
       throw new JsonException("Expected listen count not found or null.");
     }
     return new ArtistCountryInfo(artistCount.Value, country, listenCount.Value) {
+      Artists = artists,
       UnhandledProperties = rest,
     };
   }

--- a/MetaBrainz.ListenBrainz/Json/Readers/ArtistCreditReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ArtistCreditReader.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.Common.Json.Converters;
+using MetaBrainz.ListenBrainz.Objects;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers;
+
+internal class ArtistCreditReader : ObjectReader<ArtistCredit> {
+
+  public static readonly ArtistCreditReader Instance = new();
+
+  protected override ArtistCredit ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    string? creditedName = null;
+    string? joinPhrase = null;
+    Guid? id = null;
+    Dictionary<string, object?>? rest = null;
+    while (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      try {
+        reader.Read();
+        switch (prop) {
+          case "artist_credit_name":
+            creditedName = reader.GetString();
+            break;
+          case "artist_mbid":
+            id = reader.GetOptionalGuid();
+            break;
+          case "join_phrase":
+            joinPhrase = reader.GetString();
+            break;
+          default:
+            rest ??= new Dictionary<string, object?>();
+            rest[prop] = reader.GetOptionalObject(options);
+            break;
+        }
+      }
+      catch (Exception e) {
+        throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+      }
+      reader.Read();
+    }
+    if (creditedName is null) {
+      throw new JsonException("Expected artist credit name not found or null.");
+    }
+    if (id is null) {
+      throw new JsonException("Expected artist ID not found or null.");
+    }
+    if (joinPhrase is null) {
+      throw new JsonException("Expected join phrase not found or null.");
+    }
+    return new ArtistCredit(creditedName, id.Value, joinPhrase) {
+      UnhandledProperties = rest,
+    };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Readers/ArtistInfoReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ArtistInfoReader.cs
@@ -14,6 +14,7 @@ internal class ArtistInfoReader : ObjectReader<ArtistInfo> {
 
   protected override ArtistInfo ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
     int? listenCount = null;
+    Guid? mbid = null;
     IReadOnlyList<Guid>? mbids = null;
     Guid? msid = null;
     string? name = null;
@@ -23,6 +24,9 @@ internal class ArtistInfoReader : ObjectReader<ArtistInfo> {
       try {
         reader.Read();
         switch (prop) {
+          case "artist_mbid":
+            mbid = reader.GetOptionalGuid();
+            break;
           case "artist_mbids":
             mbids = reader.ReadList<Guid>(options);
             break;
@@ -53,6 +57,7 @@ internal class ArtistInfoReader : ObjectReader<ArtistInfo> {
       throw new JsonException("Expected artist name not found or null.");
     }
     return new ArtistInfo(name, listenCount.Value) {
+      Id = mbid,
       Ids = mbids,
       MessyId = msid,
       UnhandledProperties = rest,

--- a/MetaBrainz.ListenBrainz/Json/Readers/ListenReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ListenReader.cs
@@ -18,7 +18,7 @@ internal class ListenReader : ObjectReader<Listen> {
     Guid? msid = null;
     ITrackInfo? track = null;
     string? user = null;
-    long? ts = null;
+    long? listened = null;
     Dictionary<string, object?>? rest = null;
     while (reader.TokenType == JsonTokenType.PropertyName) {
       var prop = reader.GetPropertyName();
@@ -26,10 +26,10 @@ internal class ListenReader : ObjectReader<Listen> {
         reader.Read();
         switch (prop) {
           case "inserted_at":
-            inserted = reader.GetInt64();
+            inserted = reader.GetOptionalInt64();
             break;
           case "listened_at":
-            ts = reader.GetInt64();
+            listened = reader.GetOptionalInt64();
             break;
           case "recording_msid":
             msid = reader.GetGuid();
@@ -54,6 +54,9 @@ internal class ListenReader : ObjectReader<Listen> {
     if (inserted is null) {
       throw new JsonException("Expected inserted-at timestamp not found or null.");
     }
+    if (listened is null) {
+      throw new JsonException("Expected listened-at timestamp not found or null.");
+    }
     if (msid is null) {
       throw new JsonException("Expected MessyBrainz recording id not found or null.");
     }
@@ -63,10 +66,7 @@ internal class ListenReader : ObjectReader<Listen> {
     if (user is null) {
       throw new JsonException("Expected user name not found or null.");
     }
-    if (ts is null) {
-      throw new JsonException("Expected listened-at timestamp not found or null.");
-    }
-    return new Listen(inserted.Value, msid.Value, ts.Value, track, user) {
+    return new Listen(inserted.Value, listened.Value, msid.Value, track, user) {
       UnhandledProperties = rest
     };
   }

--- a/MetaBrainz.ListenBrainz/Json/Readers/MusicBrainzIdMappingsReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/MusicBrainzIdMappingsReader.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 
 using MetaBrainz.Common.Json;
 using MetaBrainz.Common.Json.Converters;
+using MetaBrainz.ListenBrainz.Interfaces;
 using MetaBrainz.ListenBrainz.Objects;
 
 namespace MetaBrainz.ListenBrainz.Json.Readers;
@@ -14,6 +15,10 @@ internal sealed class MusicBrainzIdMappingsReader : ObjectReader<MusicBrainzIdMa
 
   protected override MusicBrainzIdMappings ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
     IReadOnlyList<Guid>? artists = null;
+    long? caaId = null;
+    Guid? caaRelease = null;
+    IReadOnlyList<IArtistCredit>? credits = null;
+    string? name = null;
     Guid? recording = null;
     Guid? release = null;
     Dictionary<string, object?>? rest = null;
@@ -25,8 +30,20 @@ internal sealed class MusicBrainzIdMappingsReader : ObjectReader<MusicBrainzIdMa
           case "artist_mbids":
             artists = reader.ReadList<Guid>(options);
             break;
+          case "artists":
+            credits = reader.ReadList(ArtistCreditReader.Instance, options);
+            break;
+          case "caa_id":
+            caaId = reader.GetOptionalInt64();
+            break;
+          case "caa_release_mbid":
+            caaRelease = reader.GetOptionalGuid();
+            break;
           case "recording_mbid":
             recording = reader.GetOptionalGuid();
+            break;
+          case "recording_name":
+            name = reader.GetString();
             break;
           case "release_mbid":
             release= reader.GetOptionalGuid();
@@ -44,7 +61,11 @@ internal sealed class MusicBrainzIdMappingsReader : ObjectReader<MusicBrainzIdMa
     }
     return new MusicBrainzIdMappings {
       ArtistIds = artists,
+      Credits = credits,
+      CoverArtId = caaId,
+      CoverArtReleaseId = caaRelease,
       RecordingId = recording,
+      RecordingName = name,
       ReleaseId = release,
       UnhandledProperties = rest
     };

--- a/MetaBrainz.ListenBrainz/Json/Readers/RecordingInfoReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/RecordingInfoReader.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 
 using MetaBrainz.Common.Json;
 using MetaBrainz.Common.Json.Converters;
+using MetaBrainz.ListenBrainz.Interfaces;
 using MetaBrainz.ListenBrainz.Objects;
 
 namespace MetaBrainz.ListenBrainz.Json.Readers;
@@ -16,6 +17,9 @@ internal class RecordingInfoReader : ObjectReader<RecordingInfo> {
     IReadOnlyList<Guid>? artistMbids = null;
     Guid? artistMsid = null;
     string? artistName = null;
+    long? caaId = null;
+    Guid? caaRelease = null;
+    IReadOnlyList<IArtistCredit>? credits = null;
     int? listenCount = null;
     Guid? mbid = null;
     Guid? msid = null;
@@ -37,6 +41,15 @@ internal class RecordingInfoReader : ObjectReader<RecordingInfo> {
             break;
           case "artist_name":
             artistName = reader.GetString();
+            break;
+          case "artists":
+            credits = reader.ReadList(ArtistCreditReader.Instance, options);
+            break;
+          case "caa_id":
+            caaId = reader.GetOptionalInt64();
+            break;
+          case "caa_release_mbid":
+            caaRelease = reader.GetOptionalGuid();
             break;
           case "listen_count":
             listenCount = reader.GetInt32();
@@ -80,6 +93,9 @@ internal class RecordingInfoReader : ObjectReader<RecordingInfo> {
       ArtistIds = artistMbids,
       ArtistMessyId = artistMsid,
       ArtistName = artistName,
+      Credits = credits,
+      CoverArtId = caaId,
+      CoverArtReleaseId = caaRelease,
       Id = mbid,
       MessyId = msid,
       ReleaseId = releaseMbid,

--- a/MetaBrainz.ListenBrainz/Json/Readers/ReleaseInfoReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ReleaseInfoReader.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 
 using MetaBrainz.Common.Json;
 using MetaBrainz.Common.Json.Converters;
+using MetaBrainz.ListenBrainz.Interfaces;
 using MetaBrainz.ListenBrainz.Objects;
 
 namespace MetaBrainz.ListenBrainz.Json.Readers;
@@ -16,6 +17,9 @@ internal class ReleaseInfoReader : ObjectReader<ReleaseInfo> {
     IReadOnlyList<Guid>? artistMbids = null;
     Guid? artistMsid = null;
     string? artistName = null;
+    long? caaId = null;
+    Guid? caaRelease = null;
+    IReadOnlyList<IArtistCredit>? credits = null;
     int? listenCount = null;
     Guid? mbid = null;
     Guid? msid = null;
@@ -34,6 +38,15 @@ internal class ReleaseInfoReader : ObjectReader<ReleaseInfo> {
             break;
           case "artist_name":
             artistName = reader.GetString();
+            break;
+          case "artists":
+            credits = reader.ReadList(ArtistCreditReader.Instance, options);
+            break;
+          case "caa_id":
+            caaId = reader.GetOptionalInt64();
+            break;
+          case "caa_release_mbid":
+            caaRelease = reader.GetOptionalGuid();
             break;
           case "listen_count":
             listenCount = reader.GetInt32();
@@ -68,6 +81,9 @@ internal class ReleaseInfoReader : ObjectReader<ReleaseInfo> {
       ArtistIds = artistMbids,
       ArtistMessyId = artistMsid,
       ArtistName = artistName,
+      Credits = credits,
+      CoverArtId = caaId,
+      CoverArtReleaseId = caaRelease,
       Id = mbid,
       MessyId = msid,
       UnhandledProperties = rest,

--- a/MetaBrainz.ListenBrainz/Objects/ArtistCountryInfo.cs
+++ b/MetaBrainz.ListenBrainz/Objects/ArtistCountryInfo.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 using MetaBrainz.Common.Json;
 using MetaBrainz.ListenBrainz.Interfaces;
 
@@ -12,6 +14,8 @@ internal sealed class ArtistCountryInfo : JsonBasedObject, IArtistCountryInfo {
   }
 
   public int ArtistCount { get; }
+
+  public IReadOnlyList<IArtistInfo>? Artists { get; init; }
 
   public string Country { get; }
 

--- a/MetaBrainz.ListenBrainz/Objects/ArtistCredit.cs
+++ b/MetaBrainz.ListenBrainz/Objects/ArtistCredit.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal sealed class ArtistCredit : JsonBasedObject, IArtistCredit {
+
+  public ArtistCredit(string creditedName, Guid id, string joinPhrase) {
+    this.CreditedName = creditedName;
+    this.Id = id;
+    this.JoinPhrase = joinPhrase;
+  }
+
+  public string CreditedName { get; }
+
+  public Guid Id { get; }
+
+  public string JoinPhrase { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/ArtistInfo.cs
+++ b/MetaBrainz.ListenBrainz/Objects/ArtistInfo.cs
@@ -13,6 +13,8 @@ internal sealed class ArtistInfo : JsonBasedObject, IArtistInfo {
     this.ListenCount = listenCount;
   }
 
+  public Guid? Id { get; init; }
+
   public IReadOnlyList<Guid>? Ids { get; init; }
 
   public int ListenCount { get; }

--- a/MetaBrainz.ListenBrainz/Objects/FetchedListens.cs
+++ b/MetaBrainz.ListenBrainz/Objects/FetchedListens.cs
@@ -11,18 +11,18 @@ namespace MetaBrainz.ListenBrainz.Objects;
 [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
 internal sealed class FetchedListens : JsonBasedObject, IFetchedListens {
 
-  public FetchedListens(IReadOnlyList<IListen> listens, long ts, string user) {
+  public FetchedListens(IReadOnlyList<IListen> listens, long newest, long oldest, string user) {
     this.Listens = listens;
-    this.Timestamp = DateTimeOffset.FromUnixTimeSeconds(ts);
-    this.UnixTimestamp = ts;
+    this.Newest = DateTimeOffset.FromUnixTimeSeconds(newest);
+    this.Oldest = DateTimeOffset.FromUnixTimeSeconds(oldest);
     this.User = user;
   }
 
   public IReadOnlyList<IListen> Listens { get; }
 
-  public DateTimeOffset Timestamp { get; }
+  public DateTimeOffset Newest { get; }
 
-  public long UnixTimestamp { get; }
+  public DateTimeOffset Oldest { get; }
 
   public string User { get; }
 

--- a/MetaBrainz.ListenBrainz/Objects/Listen.cs
+++ b/MetaBrainz.ListenBrainz/Objects/Listen.cs
@@ -10,24 +10,21 @@ namespace MetaBrainz.ListenBrainz.Objects;
 [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
 internal sealed class Listen : JsonBasedObject, IListen {
 
-  public Listen(long inserted, Guid msid, long timestamp, ITrackInfo track, string user) {
+  public Listen(long inserted, long listened, Guid msid, ITrackInfo track, string user) {
     this.InsertedAt = DateTimeOffset.FromUnixTimeSeconds(inserted);
+    this.ListenedAt = DateTimeOffset.FromUnixTimeSeconds(listened);
     this.MessyRecordingId = msid;
-    this.Timestamp = DateTimeOffset.FromUnixTimeSeconds(timestamp);
     this.Track = track;
-    this.UnixTimestamp = timestamp;
     this.User = user;
   }
 
   public DateTimeOffset InsertedAt { get; }
 
+  public DateTimeOffset ListenedAt { get; }
+
   public Guid MessyRecordingId { get; }
 
-  public DateTimeOffset Timestamp { get; }
-
   public ITrackInfo Track { get; }
-
-  public long UnixTimestamp { get; }
 
   public string User { get; }
 

--- a/MetaBrainz.ListenBrainz/Objects/MusicBrainzIdMappings.cs
+++ b/MetaBrainz.ListenBrainz/Objects/MusicBrainzIdMappings.cs
@@ -13,7 +13,15 @@ internal sealed class MusicBrainzIdMappings : JsonBasedObject, IMusicBrainzIdMap
 
   public IReadOnlyList<Guid>? ArtistIds { get; init; }
 
+  public long? CoverArtId { get; init; }
+
+  public Guid? CoverArtReleaseId { get; init; }
+
+  public IReadOnlyList<IArtistCredit>? Credits { get; init; }
+
   public Guid? RecordingId { get; init; }
+
+  public string? RecordingName { get; init; }
 
   public Guid? ReleaseId { get; init; }
 

--- a/MetaBrainz.ListenBrainz/Objects/RecordingInfo.cs
+++ b/MetaBrainz.ListenBrainz/Objects/RecordingInfo.cs
@@ -19,6 +19,12 @@ internal sealed class RecordingInfo : JsonBasedObject, IRecordingInfo {
 
   public string? ArtistName { get; init; }
 
+  public long? CoverArtId { get; init; }
+
+  public Guid? CoverArtReleaseId { get; init; }
+
+  public IReadOnlyList<IArtistCredit>? Credits { get; init; }
+
   public int ListenCount { get; }
 
   public Guid? Id { get; init; }

--- a/MetaBrainz.ListenBrainz/Objects/ReleaseInfo.cs
+++ b/MetaBrainz.ListenBrainz/Objects/ReleaseInfo.cs
@@ -19,6 +19,12 @@ internal sealed class ReleaseInfo : JsonBasedObject, IReleaseInfo {
 
   public string? ArtistName { get; init; }
 
+  public long? CoverArtId { get; init; }
+
+  public Guid? CoverArtReleaseId { get; init; }
+
+  public IReadOnlyList<IArtistCredit>? Credits { get; init; }
+
   public Guid? Id { get; init; }
 
   public int ListenCount { get; }

--- a/public-api/MetaBrainz.ListenBrainz.net6.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net6.0.cs.md
@@ -734,6 +734,18 @@ public interface IRecordingInfo {
     public abstract get;
   }
 
+  long? CoverArtId {
+    public abstract get;
+  }
+
+  System.Guid? CoverArtReleaseId {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IArtistCredit>? Credits {
+    public abstract get;
+  }
+
   System.Guid? Id {
     public abstract get;
   }
@@ -779,6 +791,18 @@ public interface IReleaseInfo {
   }
 
   string? ArtistName {
+    public abstract get;
+  }
+
+  long? CoverArtId {
+    public abstract get;
+  }
+
+  System.Guid? CoverArtReleaseId {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IArtistCredit>? Credits {
     public abstract get;
   }
 

--- a/public-api/MetaBrainz.ListenBrainz.net6.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net6.0.cs.md
@@ -425,6 +425,26 @@ public interface IArtistCountryInfo {
 }
 ```
 
+### Type: IArtistCredit
+
+```cs
+public interface IArtistCredit {
+
+  string CreditedName {
+    public abstract get;
+  }
+
+  System.Guid Id {
+    public abstract get;
+  }
+
+  string? JoinPhrase {
+    public abstract get;
+  }
+
+}
+```
+
 ### Type: IArtistInfo
 
 ```cs
@@ -642,7 +662,23 @@ public interface IMusicBrainzIdMappings {
     public abstract get;
   }
 
+  long? CoverArtId {
+    public abstract get;
+  }
+
+  System.Guid? CoverArtReleaseId {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IArtistCredit>? Credits {
+    public abstract get;
+  }
+
   System.Guid? RecordingId {
+    public abstract get;
+  }
+
+  string? RecordingName {
     public abstract get;
   }
 

--- a/public-api/MetaBrainz.ListenBrainz.net6.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net6.0.cs.md
@@ -518,11 +518,11 @@ public interface IFetchedListens : MetaBrainz.Common.Json.IJsonBasedObject {
     public abstract get;
   }
 
-  System.DateTimeOffset Timestamp {
+  System.DateTimeOffset Newest {
     public abstract get;
   }
 
-  long UnixTimestamp {
+  System.DateTimeOffset Oldest {
     public abstract get;
   }
 
@@ -578,19 +578,15 @@ public interface IListen : MetaBrainz.Common.Json.IJsonBasedObject {
     public abstract get;
   }
 
+  System.DateTimeOffset ListenedAt {
+    public abstract get;
+  }
+
   System.Guid MessyRecordingId {
     public abstract get;
   }
 
-  System.DateTimeOffset Timestamp {
-    public abstract get;
-  }
-
   ITrackInfo Track {
-    public abstract get;
-  }
-
-  long UnixTimestamp {
     public abstract get;
   }
 

--- a/public-api/MetaBrainz.ListenBrainz.net6.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net6.0.cs.md
@@ -410,6 +410,10 @@ public interface IArtistCountryInfo {
     public abstract get;
   }
 
+  System.Collections.Generic.IReadOnlyList<IArtistInfo>? Artists {
+    public abstract get;
+  }
+
   string Country {
     public abstract get;
   }

--- a/public-api/MetaBrainz.ListenBrainz.net6.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net6.0.cs.md
@@ -426,6 +426,10 @@ public interface IArtistCountryInfo {
 ```cs
 public interface IArtistInfo : MetaBrainz.Common.Json.IJsonBasedObject {
 
+  System.Guid? Id {
+    public abstract get;
+  }
+
   System.Collections.Generic.IReadOnlyList<System.Guid>? Ids {
     public abstract get;
   }

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -734,6 +734,18 @@ public interface IRecordingInfo {
     public abstract get;
   }
 
+  long? CoverArtId {
+    public abstract get;
+  }
+
+  System.Guid? CoverArtReleaseId {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IArtistCredit>? Credits {
+    public abstract get;
+  }
+
   System.Guid? Id {
     public abstract get;
   }
@@ -779,6 +791,18 @@ public interface IReleaseInfo {
   }
 
   string? ArtistName {
+    public abstract get;
+  }
+
+  long? CoverArtId {
+    public abstract get;
+  }
+
+  System.Guid? CoverArtReleaseId {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IArtistCredit>? Credits {
     public abstract get;
   }
 

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -425,6 +425,26 @@ public interface IArtistCountryInfo {
 }
 ```
 
+### Type: IArtistCredit
+
+```cs
+public interface IArtistCredit {
+
+  string CreditedName {
+    public abstract get;
+  }
+
+  System.Guid Id {
+    public abstract get;
+  }
+
+  string? JoinPhrase {
+    public abstract get;
+  }
+
+}
+```
+
 ### Type: IArtistInfo
 
 ```cs
@@ -642,7 +662,23 @@ public interface IMusicBrainzIdMappings {
     public abstract get;
   }
 
+  long? CoverArtId {
+    public abstract get;
+  }
+
+  System.Guid? CoverArtReleaseId {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IArtistCredit>? Credits {
+    public abstract get;
+  }
+
   System.Guid? RecordingId {
+    public abstract get;
+  }
+
+  string? RecordingName {
     public abstract get;
   }
 

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -518,11 +518,11 @@ public interface IFetchedListens : MetaBrainz.Common.Json.IJsonBasedObject {
     public abstract get;
   }
 
-  System.DateTimeOffset Timestamp {
+  System.DateTimeOffset Newest {
     public abstract get;
   }
 
-  long UnixTimestamp {
+  System.DateTimeOffset Oldest {
     public abstract get;
   }
 
@@ -578,19 +578,15 @@ public interface IListen : MetaBrainz.Common.Json.IJsonBasedObject {
     public abstract get;
   }
 
+  System.DateTimeOffset ListenedAt {
+    public abstract get;
+  }
+
   System.Guid MessyRecordingId {
     public abstract get;
   }
 
-  System.DateTimeOffset Timestamp {
-    public abstract get;
-  }
-
   ITrackInfo Track {
-    public abstract get;
-  }
-
-  long UnixTimestamp {
     public abstract get;
   }
 

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -410,6 +410,10 @@ public interface IArtistCountryInfo {
     public abstract get;
   }
 
+  System.Collections.Generic.IReadOnlyList<IArtistInfo>? Artists {
+    public abstract get;
+  }
+
   string Country {
     public abstract get;
   }

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -426,6 +426,10 @@ public interface IArtistCountryInfo {
 ```cs
 public interface IArtistInfo : MetaBrainz.Common.Json.IJsonBasedObject {
 
+  System.Guid? Id {
+    public abstract get;
+  }
+
   System.Collections.Generic.IReadOnlyList<System.Guid>? Ids {
     public abstract get;
   }


### PR DESCRIPTION
This adjusts the processing to handle the current structures returned by the ListenBrainz API. This should resolve all cases where the `UnhandledProperties` field was non-null before.

- `IArtistCountryInfo` now includes an `Artists` property, which will have `IArtistInfo` instances for all listened-to artists from that country
- `IArtistInfo` now includes an `Id` property, containing a single MusicBrainz ID
  - this may fully replace the existing multi-valued `Ids` property; once confirmed, that will be marked `[Obsolete]`
- `IFetchedListens` now has an `Oldest` property, containing the timestamp of the user's oldest recorded listen
  - the existing `Timestamp` property was renamed to `Newest`
    - the documentation for `Newest` has been corrected as well; it is the timestamp of the user's newest recorded listen, unrelated to the range returned by that specific call
  - the existing `UnixTimestamp` property was dropped (all targeted frameworks allow easy conversion of the `DateTimeOffset` to a Unix time value)
- similarly, `IListen` has its `Timestamp` property renamed to `ListenedAt`, and the `UnixTimestamp` property dropped
- `IMusicBrainzIdMappings` has a new `RecordingName` property
- there is a new `IArtistCredit` type, with information about a MusicBrainz artist credit
- `IMusicBrainzIdMappings`, `IRecordingInfo` and `IReleaseInfo` have three new properties:
  - `CoverArtId`: the numeric ID of the associated CoverArt Archive entry
  - `CoverArtReleaseId`: the MusicBrainz ID of the release linked to the associated CoverArt Archive entry
  - `Credits`: a list of associated artist credits

Fixes #47.