### PR TITLE
Update `MetaBrainz.Build.Sdk` to version 4.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
       id: setup
       with:
         dotnet-version: ${{env.dotnet-version}}
+        dotnet-quality: ga
       env:
         NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
     - name: Create global.json to force use of .NET SDK ${{steps.setup.outputs.dotnet-version}}
@@ -46,7 +47,7 @@ jobs:
         path: "output/package/${{matrix.configuration}}/*.*nupkg"
     - name: Publish (NuGet - GitHub Packages)
       if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
-      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg -s https://nuget.pkg.github.com/zastai/index.json -k ${{secrets.GITHUB_TOKEN}}"
+      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg --skip-duplicate -s https://nuget.pkg.github.com/zastai/index.json -k ${{secrets.GITHUB_TOKEN}}"
     - name: Publish (NuGet - nuget.org)
       if: matrix.configuration == 'Release' && startsWith(github.ref, 'refs/tags/v')
-      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}"
+      run: "dotnet nuget push output/package/${{matrix.configuration}}/*.nupkg --skip-duplicate -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}"

--- a/MetaBrainz.ListenBrainz/ListenBrainz.cs
+++ b/MetaBrainz.ListenBrainz/ListenBrainz.cs
@@ -316,13 +316,7 @@ public sealed partial class ListenBrainz : IDisposable {
 
   private HttpClient Client {
     get {
-#if NET6_0
-      if (this._disposed) {
-        throw new ObjectDisposedException(nameof(ListenBrainz));
-      }
-#else
       ObjectDisposedException.ThrowIf(this._disposed, typeof(ListenBrainz));
-#endif
       if (this._client is null) {
         var client = this._clientCreation?.Invoke() ?? new HttpClient();
         this._userAgent.ForEach(client.DefaultRequestHeaders.UserAgent.Add);

--- a/MetaBrainz.ListenBrainz/MetaBrainz.ListenBrainz.csproj
+++ b/MetaBrainz.ListenBrainz/MetaBrainz.ListenBrainz.csproj
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
 
-  <Sdk Name="MetaBrainz.Build.Sdk" Version="3.1.2" />
+  <Sdk Name="MetaBrainz.Build.Sdk" Version="4.0.0" />
 
   <PropertyGroup>
     <Authors>Zastai</Authors>
     <Title>ListenBrainz Web Service Client Library</Title>
     <Description>This package provides classes for accessing the ListenBrainz API (v1).</Description>
     <PackageCopyrightOwners>Tim Van Holder</PackageCopyrightOwners>
-    <PackageCopyrightYears>2018, 2019, 2020, 2021, 2022, 2023</PackageCopyrightYears>
+    <PackageCopyrightYears>2018, 2019, 2020, 2021, 2022, 2023, 2025</PackageCopyrightYears>
     <PackageRepositoryName>MetaBrainz.ListenBrainz</PackageRepositoryName>
     <PackageTags>ListenBrainz music metadata listens audioscrobbler last.fm</PackageTags>
     <Version>4.0.1-pre</Version>

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ ListenBrainz.TraceSource.Listeners.Add(listener);
 
 #### In Configuration
 
-Starting from .NET 7 your application can also be set up to read tracing
-configuration from the application configuration file. To do so, the
-application needs to add the following to its startup code:
+Your application can also be set up to read tracing configuration from
+the application configuration file. To do so, the following needs to be
+added to its startup code:
 
 ```cs
 System.Diagnostics.TraceConfiguration.Register();


### PR DESCRIPTION
This means we now target `net8.0` only.

This also tweaks the build, requesting GA .NET SDKs only (so no previews), and passing `--skip-duplicate` on the NuGet push, to make it easier to rerun the build for a tag if something goes wrong during publishing.
