### PR TITLE
Update `MetaBrainz.Common` and `MetaBrainz.Common.Json`.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,8 +4,8 @@
   <!-- Package Versions -->
   <ItemGroup>
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.2" />
-    <PackageVersion Include="MetaBrainz.Common" Version="3.0.0" />
-    <PackageVersion Include="MetaBrainz.Common.Json" Version="6.0.2" />
+    <PackageVersion Include="MetaBrainz.Common" Version="4.0.0" />
+    <PackageVersion Include="MetaBrainz.Common.Json" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/MetaBrainz.ListenBrainz/Interfaces/ILatestImport.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ILatestImport.cs
@@ -16,7 +16,7 @@ public interface ILatestImport : IJsonBasedObject {
 
   /// <summary>
   /// The timestamp of the newest listen submitted in previous imports, expressed as the number of seconds since
-  /// <see cref="UnixTime.Epoch">the Unix time epoch</see>.
+  /// <see cref="DateTimeOffset.UnixEpoch">the Unix time epoch</see>.
   /// </summary>
   long? UnixTimestamp { get; }
 


### PR DESCRIPTION
To version 4.0.0 and 7.0.0, respectively.

Update a doc comment to refer to `DateTimeOffset.UnixEpoch` instead of the removed `UnixTime.Epoch`.