### PR TITLE
Add user release group statistics.

### DIFF
--- a/MetaBrainz.ListenBrainz/Interfaces/IReleaseGroupInfo.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IReleaseGroupInfo.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+
+using JetBrains.Annotations;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>Statistical information about a release group.</summary>
+[PublicAPI]
+public interface IReleaseGroupInfo {
+
+  /// <summary>The MusicBrainz IDs for the release group's artist(s), if available.</summary>
+  IReadOnlyList<Guid>? ArtistIds { get; }
+
+  /// <summary>The release group's artist's name, if available.</summary>
+  string? ArtistName { get; }
+
+  /// <summary>The internal ID for the release group in the CoverArt Archive.</summary>
+  long? CoverArtId { get; }
+
+  /// <summary>The MusicBrainz ID for the release group in the CoverArt Archive.</summary>
+  Guid? CoverArtReleaseGroupId { get; }
+
+  /// <summary>The MusicBrainz credits for the release group's artists.</summary>
+  IReadOnlyList<IArtistCredit>? Credits { get; }
+
+  /// <summary>The MusicBrainz ID for the release group, if available.</summary>
+  Guid? Id { get; }
+
+  /// <summary>The number of times the release group's tracks were listened to.</summary>
+  int ListenCount { get; }
+
+  /// <summary>The release group's name.</summary>
+  string Name { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/IReleaseInfo.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IReleaseInfo.cs
@@ -18,13 +18,13 @@ public interface IReleaseInfo {
   /// <summary>The release's artist's name, if available.</summary>
   string? ArtistName { get; }
 
-  /// <summary>The internal ID for the track's release in the CoverArt Archive.</summary>
+  /// <summary>The internal ID for the release in the CoverArt Archive.</summary>
   long? CoverArtId { get; }
 
-  /// <summary>The MusicBrainz ID for the track's release in the CoverArt Archive.</summary>
+  /// <summary>The MusicBrainz ID for the release in the CoverArt Archive.</summary>
   Guid? CoverArtReleaseId { get; }
 
-  /// <summary>The MusicBrainz credits for the track's artists.</summary>
+  /// <summary>The MusicBrainz credits for the release's artists.</summary>
   IReadOnlyList<IArtistCredit>? Credits { get; }
 
   /// <summary>The MusicBrainz ID for the release, if available.</summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/IUserReleaseGroupStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IUserReleaseGroupStatistics.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+using JetBrains.Annotations;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>A user's most-listened releases.</summary>
+[PublicAPI]
+public interface IUserReleaseGroupStatistics : IUserStatistics {
+
+  /// <summary>Information about the release groups.</summary>
+  IReadOnlyList<IReleaseGroupInfo>? ReleaseGroups { get; }
+
+  /// <summary>The offset of these statistics from the start of the full set.</summary>
+  int? Offset { get; }
+
+  /// <summary>The total number of (distinct) releases listened to, if available.</summary>
+  int? TotalCount { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Converters.cs
+++ b/MetaBrainz.ListenBrainz/Json/Converters.cs
@@ -23,6 +23,7 @@ internal static class Converters {
       yield return UserListeningActivityReader.Instance;
       yield return UserRecordingStatisticsReader.Instance;
       yield return UserReleaseStatisticsReader.Instance;
+      yield return UserReleaseGroupStatisticsReader.Instance;
     }
   }
 

--- a/MetaBrainz.ListenBrainz/Json/Readers/PayloadReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/PayloadReader.cs
@@ -35,7 +35,8 @@ internal abstract class PayloadReader<T> : ObjectReader<T> {
     if (n != count.Value) {
       throw new JsonException($"The size of the list of items ({n}) does not match the reported item count ({count}).");
     }
-    return items ?? Array.Empty<TItem>(); // treat missing/null the same as []
+    // treat missing/null the same as []
+    return items ?? [ ];
   }
 
 }

--- a/MetaBrainz.ListenBrainz/Json/Readers/ReleaseGroupInfoReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ReleaseGroupInfoReader.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.Common.Json.Converters;
+using MetaBrainz.ListenBrainz.Interfaces;
+using MetaBrainz.ListenBrainz.Objects;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers;
+
+internal class ReleaseGroupInfoReader : ObjectReader<ReleaseGroupInfo> {
+
+  public static readonly ReleaseGroupInfoReader Instance = new();
+
+
+  protected override ReleaseGroupInfo ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    IReadOnlyList<Guid>? artistMbids = null;
+    string? artistName = null;
+    long? caaId = null;
+    Guid? caaRelease = null;
+    IReadOnlyList<IArtistCredit>? credits = null;
+    int? listenCount = null;
+    Guid? mbid = null;
+    string? name = null;
+    Dictionary<string, object?>? rest = null;
+    while (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      try {
+        reader.Read();
+        switch (prop) {
+          case "artist_mbids":
+            artistMbids = reader.ReadList<Guid>(options);
+            break;
+          case "artist_name":
+            artistName = reader.GetString();
+            break;
+          case "artists":
+            credits = reader.ReadList(ArtistCreditReader.Instance, options);
+            break;
+          case "caa_id":
+            caaId = reader.GetOptionalInt64();
+            break;
+          case "caa_release_mbid":
+            caaRelease = reader.GetOptionalGuid();
+            break;
+          case "listen_count":
+            listenCount = reader.GetInt32();
+            break;
+          case "release_group_mbid":
+            mbid = reader.GetOptionalGuid();
+            break;
+          case "release_group_name":
+            name = reader.GetString();
+            break;
+          default:
+            rest ??= new Dictionary<string, object?>();
+            rest[prop] = reader.GetOptionalObject(options);
+            break;
+        }
+      }
+      catch (Exception e) {
+        throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+      }
+      reader.Read();
+    }
+    if (listenCount is null) {
+      throw new JsonException("Expected listen count not found or null.");
+    }
+    if (name is null) {
+      throw new JsonException("Expected release group name not found or null.");
+    }
+    return new ReleaseGroupInfo(name, listenCount.Value) {
+      ArtistIds = artistMbids,
+      ArtistName = artistName,
+      Credits = credits,
+      CoverArtId = caaId,
+      CoverArtReleaseGroupId = caaRelease,
+      Id = mbid,
+      UnhandledProperties = rest,
+    };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Readers/UserReleaseGroupStatisticsReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/UserReleaseGroupStatisticsReader.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+using MetaBrainz.ListenBrainz.Objects;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers;
+
+internal sealed class UserReleaseGroupStatisticsReader : PayloadReader<UserReleaseGroupStatistics> {
+
+  public static readonly UserReleaseGroupStatisticsReader Instance = new();
+
+  protected override UserReleaseGroupStatistics ReadPayload(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    IReadOnlyList<IReleaseGroupInfo>? releaseGroups = null;
+    int? count = null;
+    DateTimeOffset? lastUpdated = null;
+    DateTimeOffset? newestListen = null;
+    int? offset = null;
+    DateTimeOffset? oldestListen = null;
+    StatisticsRange? range = null;
+    int? totalCount = null;
+    string? user = null;
+    Dictionary<string, object?>? rest = null;
+    while (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      try {
+        reader.Read();
+        switch (prop) {
+          case "release_groups":
+            releaseGroups = reader.ReadList(ReleaseGroupInfoReader.Instance, options);
+            break;
+          case "count":
+            count = reader.GetInt32();
+            break;
+          case "from_ts": {
+            var unixTime = reader.GetOptionalInt64();
+            oldestListen = unixTime is null ? null : DateTimeOffset.FromUnixTimeSeconds(unixTime.Value);
+            break;
+          }
+          case "last_updated":
+            lastUpdated = DateTimeOffset.FromUnixTimeSeconds(reader.GetInt64());
+            break;
+          case "offset":
+            offset = reader.GetInt32();
+            break;
+          case "range":
+            range = EnumHelper.ParseStatisticsRange(reader.GetString());
+            if (range == StatisticsRange.Unknown) {
+              goto default; // also register it as an unhandled property
+            }
+            break;
+          case "to_ts": {
+            var unixTime = reader.GetOptionalInt64();
+            newestListen = unixTime is null ? null : DateTimeOffset.FromUnixTimeSeconds(unixTime.Value);
+            break;
+          }
+          case "total_release_group_count":
+            totalCount = reader.GetInt32();
+            break;
+          case "user_id":
+            user = reader.GetString();
+            break;
+          default:
+            rest ??= new Dictionary<string, object?>();
+            rest[prop] = reader.GetOptionalObject(options);
+            break;
+        }
+      }
+      catch (Exception e) {
+        throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+      }
+      reader.Read();
+    }
+    releaseGroups = PayloadReader<UserReleaseGroupStatistics>.VerifyPayloadContents(count, releaseGroups);
+    if (lastUpdated is null) {
+      throw new JsonException("Expected last-updated timestamp not found or null.");
+    }
+    if (range is null) {
+      throw new JsonException("Expected range not found or null.");
+    }
+    if (user is null) {
+      throw new JsonException("Expected user id not found or null.");
+    }
+    return new UserReleaseGroupStatistics(lastUpdated.Value, range.Value, user) {
+      NewestListen = newestListen,
+      Offset = offset,
+      OldestListen = oldestListen,
+      ReleaseGroups = releaseGroups,
+      TotalCount = totalCount,
+      UnhandledProperties = rest,
+    };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.cs
+++ b/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.cs
@@ -237,6 +237,35 @@ public sealed partial class ListenBrainz {
 
   #endregion
 
+  #region /1/stats/user/xxx/release-groups
+
+  /// <summary>Gets statistics about a user's most listened-to releases ("albums").</summary>
+  /// <param name="user">The user for whom the statistics are requested.</param>
+  /// <param name="count">
+  /// The (maximum) number of entries to return. If not specified (or <see langword="null"/>), all available information will be
+  /// returned.
+  /// </param>
+  /// <param name="offset">
+  /// The offset (from the start of the results) of the statistics to return. If not specified (or specified as zero or
+  /// <see langword="null"/>), the top most listened-to releases will be returned.
+  /// </param>
+  /// <param name="range">The range of data to include in the statistics.</param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>
+  /// The requested releases statistics, or <see langword="null"/> if statistics have not yet been computed for the user.
+  /// </returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IUserReleaseGroupStatistics?> GetReleaseGroupStatisticsAsync(string user, int? count = null, int? offset = null,
+                                                                           StatisticsRange? range = null,
+                                                                           CancellationToken cancellationToken = default) {
+    var address = $"stats/user/{user}/release-groups";
+    var options = ListenBrainz.OptionsForGetStatistics(count, offset, range);
+    return this.GetOptionalAsync<IUserReleaseGroupStatistics, UserReleaseGroupStatistics>(address, options, cancellationToken);
+  }
+
+  #endregion
+
   #region /1/stats/user/xxx/releases
 
   /// <summary>Gets statistics about a user's most listened-to releases ("albums").</summary>

--- a/MetaBrainz.ListenBrainz/Objects/ReleaseGroupInfo.cs
+++ b/MetaBrainz.ListenBrainz/Objects/ReleaseGroupInfo.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal sealed class ReleaseGroupInfo : JsonBasedObject, IReleaseGroupInfo {
+
+  public ReleaseGroupInfo(string name, int listenCount) {
+    this.Name = name;
+    this.ListenCount = listenCount;
+  }
+
+  public IReadOnlyList<Guid>? ArtistIds { get; init; }
+
+  public string? ArtistName { get; init; }
+
+  public long? CoverArtId { get; init; }
+
+  public Guid? CoverArtReleaseGroupId { get; init; }
+
+  public IReadOnlyList<IArtistCredit>? Credits { get; init; }
+
+  public Guid? Id { get; init; }
+
+  public int ListenCount { get; }
+
+  public string Name { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/UserReleaseGroupStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Objects/UserReleaseGroupStatistics.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal sealed class UserReleaseGroupStatistics : UserStatistics, IUserReleaseGroupStatistics {
+
+  public UserReleaseGroupStatistics(DateTimeOffset lastUpdated, StatisticsRange range, string user)
+  : base(lastUpdated, range, user)
+  { }
+
+  public IReadOnlyList<IReleaseGroupInfo>? ReleaseGroups { get; init; }
+
+  public int? Offset { get; init; }
+
+  public int? TotalCount { get; init; }
+
+}

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -150,6 +150,8 @@ public sealed class ListenBrainz : System.IDisposable {
 
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IUserRecordingStatistics?> GetRecordingStatisticsAsync(string user, int? count = default, int? offset = default, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
 
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IUserReleaseGroupStatistics?> GetReleaseGroupStatisticsAsync(string user, int? count = default, int? offset = default, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
+
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IUserReleaseStatistics?> GetReleaseStatisticsAsync(string user, int? count = default, int? offset = default, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
 
   public System.Threading.Tasks.Task ImportListensAsync(params MetaBrainz.ListenBrainz.Interfaces.ISubmittedListen[] listens);
@@ -709,6 +711,46 @@ public interface IRecordingInfo {
 }
 ```
 
+### Type: IReleaseGroupInfo
+
+```cs
+public interface IReleaseGroupInfo {
+
+  System.Collections.Generic.IReadOnlyList<System.Guid>? ArtistIds {
+    public abstract get;
+  }
+
+  string? ArtistName {
+    public abstract get;
+  }
+
+  long? CoverArtId {
+    public abstract get;
+  }
+
+  System.Guid? CoverArtReleaseGroupId {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IArtistCredit>? Credits {
+    public abstract get;
+  }
+
+  System.Guid? Id {
+    public abstract get;
+  }
+
+  int ListenCount {
+    public abstract get;
+  }
+
+  string Name {
+    public abstract get;
+  }
+
+}
+```
+
 ### Type: IReleaseInfo
 
 ```cs
@@ -947,6 +989,26 @@ public interface IUserRecordingStatistics : IStatistics, IUserStatistics, MetaBr
   }
 
   System.Collections.Generic.IReadOnlyList<IRecordingInfo>? Recordings {
+    public abstract get;
+  }
+
+  int? TotalCount {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IUserReleaseGroupStatistics
+
+```cs
+public interface IUserReleaseGroupStatistics : IStatistics, IUserStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
+
+  int? Offset {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IReleaseGroupInfo>? ReleaseGroups {
     public abstract get;
   }
 


### PR DESCRIPTION
This adds support for the `/1/stats/user/xxx/release-groups` endpoint, including the artist credits (not mentioned in the docs).

This also fixes a few doc comments on `IReleaseInfo`.