### PR TITLE
Adjust artist statistics.

### DIFF
--- a/MetaBrainz.ListenBrainz/Interfaces/IArtistStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IArtistStatistics.cs
@@ -17,4 +17,7 @@ public interface IArtistStatistics {
   /// <summary>The offset of the artist lists (in each time range) from the start of the full set.</summary>
   int Offset { get; }
 
+  /// <summary>The total number of (distinct) artists listened to.</summary>
+  public int TotalCount { get; }
+
 }

--- a/MetaBrainz.ListenBrainz/Interfaces/ISiteArtistStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ISiteArtistStatistics.cs
@@ -4,5 +4,4 @@ namespace MetaBrainz.ListenBrainz.Interfaces;
 
 /// <summary>Statistics about how many times particular artists were listened to.</summary>
 [PublicAPI]
-public interface ISiteArtistStatistics : IArtistStatistics, IStatistics {
-}
+public interface ISiteArtistStatistics : IArtistStatistics, IStatistics;

--- a/MetaBrainz.ListenBrainz/Interfaces/IUserArtistStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IUserArtistStatistics.cs
@@ -4,9 +4,4 @@ namespace MetaBrainz.ListenBrainz.Interfaces;
 
 /// <summary>A user's most-listened artists.</summary>
 [PublicAPI]
-public interface IUserArtistStatistics : IArtistStatistics, IUserStatistics {
-
-  /// <summary>The total number of (distinct) artists listened to, if available.</summary>
-  int TotalCount { get; }
-
-}
+public interface IUserArtistStatistics : IArtistStatistics, IUserStatistics;

--- a/MetaBrainz.ListenBrainz/Json/Readers/PayloadReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/PayloadReader.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Text.Json;
 

--- a/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.cs
+++ b/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.cs
@@ -79,9 +79,39 @@ public sealed partial class ListenBrainz {
     return options;
   }
 
-  #region /1/stats/sitewide
+  #region artist-activity
 
-  #region /1/stats/sitewide/artists
+  #endregion
+
+  #region artist-evolution-activity
+
+  #endregion
+
+  #region artist-map
+
+  /// <summary>Gets information about the number of artists a user has listened to, grouped by their country.</summary>
+  /// <param name="user">The user for whom the information is requested.</param>
+  /// <param name="range">The range of data to include in the statistics.</param>
+  /// <param name="forceRecalculation">Indicates whether recalculation of the data should be requested.</param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested information, or <see langword="null"/> if it has not yet been computed for the user.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IUserArtistMap?> GetArtistMapAsync(string user, StatisticsRange? range = null, bool forceRecalculation = false,
+                                                 CancellationToken cancellationToken = default) {
+    var options = new Dictionary<string, string>(2);
+    if (range is not null) {
+      options.Add("range", range.Value.ToJson());
+    }
+    if (forceRecalculation) {
+      options.Add("force_recalculate", "true");
+    }
+    return this.GetOptionalAsync<IUserArtistMap, UserArtistMap>($"stats/user/{user}/artist-map", options, cancellationToken);
+  }
+
+  #endregion
+
+  #region artists
 
   /// <summary>Gets statistics about the most listened-to artists.</summary>
   /// <param name="count">
@@ -108,38 +138,6 @@ public sealed partial class ListenBrainz {
     var options = ListenBrainz.OptionsForGetStatistics(count, offset, range);
     return this.GetOptionalAsync<ISiteArtistStatistics, SiteArtistStatistics>("stats/sitewide/artists", options, cancellationToken);
   }
-
-  #endregion
-
-  #endregion
-
-  #region /1/stats/user/xxx
-
-  #region /1/stats/user/xxx/artist-map
-
-  /// <summary>Gets information about the number of artists a user has listened to, grouped by their country.</summary>
-  /// <param name="user">The user for whom the information is requested.</param>
-  /// <param name="range">The range of data to include in the statistics.</param>
-  /// <param name="forceRecalculation">Indicates whether recalculation of the data should be requested.</param>
-  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested information, or <see langword="null"/> if it has not yet been computed for the user.</returns>
-  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
-  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
-  public Task<IUserArtistMap?> GetArtistMapAsync(string user, StatisticsRange? range = null, bool forceRecalculation = false,
-                                                 CancellationToken cancellationToken = default) {
-    var options = new Dictionary<string, string>(2);
-    if (range is not null) {
-      options.Add("range", range.Value.ToJson());
-    }
-    if (forceRecalculation) {
-      options.Add("force_recalculate", "true");
-    }
-    return this.GetOptionalAsync<IUserArtistMap, UserArtistMap>($"stats/user/{user}/artist-map", options, cancellationToken);
-  }
-
-  #endregion
-
-  #region /1/stats/user/xxx/artists
 
   /// <summary>Gets statistics about a user's most listened-to artists.</summary>
   /// <param name="user">The user for whom the statistics are requested.</param>
@@ -168,7 +166,7 @@ public sealed partial class ListenBrainz {
 
   #endregion
 
-  #region /1/stats/user/xxx/daily-activity
+  #region daily-activity
 
   /// <summary>Gets information about how a user's listens are spread across the days of the week.</summary>
   /// <param name="user">The user for whom the information is requested.</param>
@@ -186,7 +184,19 @@ public sealed partial class ListenBrainz {
 
   #endregion
 
-  #region /1/stats/user/xxx/listening-activity
+  #region era-activity
+
+  #endregion
+
+  #region genre-activity
+
+  #endregion
+
+  #region listeners
+
+  #endregion
+
+  #region listening-activity
 
   /// <summary>Gets information about how many listens a user has submitted over a period of time.</summary>
   /// <param name="user">The user for whom the information is requested.</param>
@@ -208,7 +218,7 @@ public sealed partial class ListenBrainz {
 
   #endregion
 
-  #region /1/stats/user/xxx/recordings
+  #region recordings
 
   /// <summary>Gets statistics about a user's most listened-to recordings ("tracks").</summary>
   /// <param name="user">The user for whom the statistics are requested.</param>
@@ -237,9 +247,9 @@ public sealed partial class ListenBrainz {
 
   #endregion
 
-  #region /1/stats/user/xxx/release-groups
+  #region release-groups
 
-  /// <summary>Gets statistics about a user's most listened-to releases ("albums").</summary>
+  /// <summary>Gets statistics about a user's most listened-to release groups (sets of all editions of an "album").</summary>
   /// <param name="user">The user for whom the statistics are requested.</param>
   /// <param name="count">
   /// The (maximum) number of entries to return. If not specified (or <see langword="null"/>), all available information will be
@@ -247,7 +257,7 @@ public sealed partial class ListenBrainz {
   /// </param>
   /// <param name="offset">
   /// The offset (from the start of the results) of the statistics to return. If not specified (or specified as zero or
-  /// <see langword="null"/>), the top most listened-to releases will be returned.
+  /// <see langword="null"/>), the top most listened-to release groups will be returned.
   /// </param>
   /// <param name="range">The range of data to include in the statistics.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
@@ -266,7 +276,7 @@ public sealed partial class ListenBrainz {
 
   #endregion
 
-  #region /1/stats/user/xxx/releases
+  #region releases
 
   /// <summary>Gets statistics about a user's most listened-to releases ("albums").</summary>
   /// <param name="user">The user for whom the statistics are requested.</param>
@@ -294,6 +304,39 @@ public sealed partial class ListenBrainz {
   }
 
   #endregion
+
+  #region year-in-music
+
+  // While the endpoint is listed in the docs, its payload is not.
+  // The top level has:
+  // - user_name: the name of the user
+  // - data: the year-in-music data, with the following fields:
+  //   - artist_map: same contents as the artist-map entry point (with the artist data limited to name, mbid and listen count)
+  //   - day_of_week: name of a day of the week; presumably the day the most listens are recorded
+  //   - listens_per_day: list of objects (one per day of the year):
+  //     - time_range: string containing the date (e.g. "02 October 2022")
+  //     - from_ts/to_ts: Unix timestamps
+  //     - listen_count
+  //   - most_listened_year: dictionary mapping a year (as a string) to the number of listens for recordings from that year
+  //   - new_releases_of_top_artists: list of release group info
+  //     - similar to what's in the RG stats, but "title" instead of "release_group_name", and no listen count
+  //   - playlist-top-discoveries-for-year
+  //     - ListenBrainz Troi playlist data
+  //   - playlist-top-discoveries-for-year-coverart: map of mbid to CAA URL
+  //   - playlist-top-missed-recordings-for-year
+  //     - ListenBrainz Troi playlist data
+  //   - playlist-top-missed-recordings-for-year-coverart: map of mbid to CAA URL
+  //   - similar_users: map of user names (string) to a decimal number (0-1)
+  //   - top_artists: list of artist info (similar to what's in the artist map: name, mbid, listen count)
+  //   - top_recordings: list of record info (similar to what's in the recording stats)
+  //   - top_releases: list of release info (similar to what's in the release stats)
+  //   - total_artists_count (an integer)
+  //   - total_listen_count (an integer)
+  //   - total_listening_time (a decimal number; presumably expressed in minutes)
+  //   - total_new_artists_discovered (an integer)
+  //   - total_recordings_count (an integer)
+  //   - total_releases_count (an integer)
+  //   - yim_artist_map: identical to artist_map
 
   #endregion
 

--- a/MetaBrainz.ListenBrainz/Objects/SiteArtistStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Objects/SiteArtistStatistics.cs
@@ -5,18 +5,15 @@ using MetaBrainz.ListenBrainz.Interfaces;
 
 namespace MetaBrainz.ListenBrainz.Objects;
 
-internal sealed class SiteArtistStatistics : Statistics, ISiteArtistStatistics {
-
-  public SiteArtistStatistics(int count, DateTimeOffset lastUpdated, int offset, StatisticsRange range)
-  : base(lastUpdated, range) {
-    this.Count = count;
-    this.Offset = offset;
-  }
+internal sealed class SiteArtistStatistics(int count, int totalCount, DateTimeOffset lastUpdated, int offset, StatisticsRange range)
+  : Statistics(lastUpdated, range), ISiteArtistStatistics {
 
   public IReadOnlyList<IArtistInfo>? Artists { get; init; }
 
-  public int Count { get; }
+  public int Count { get; } = count;
 
-  public int Offset { get; }
+  public int Offset { get; } = offset;
+
+  public int TotalCount { get; } = totalCount;
 
 }

--- a/MetaBrainz.ListenBrainz/Objects/UserArtistStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Objects/UserArtistStatistics.cs
@@ -5,22 +5,16 @@ using MetaBrainz.ListenBrainz.Interfaces;
 
 namespace MetaBrainz.ListenBrainz.Objects;
 
-internal sealed class UserArtistStatistics : UserStatistics, IUserArtistStatistics {
-
-  public UserArtistStatistics(int count, int totalCount, DateTimeOffset lastUpdated, int offset, StatisticsRange range, string user)
-  : base(lastUpdated, range, user)
-  {
-    this.Count = count;
-    this.Offset = offset;
-    this.TotalCount = totalCount;
-  }
+internal sealed class UserArtistStatistics(int count, int totalCount, DateTimeOffset lastUpdated, int offset, StatisticsRange range,
+                                           string user)
+  : UserStatistics(lastUpdated, range, user), IUserArtistStatistics {
 
   public IReadOnlyList<IArtistInfo>? Artists { get; init; }
 
-  public int Count { get; }
+  public int Count { get; } = count;
 
-  public int Offset { get; }
+  public int Offset { get; } = offset;
 
-  public int TotalCount { get; }
+  public int TotalCount { get; } = totalCount;
 
 }

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -424,6 +424,10 @@ public interface IArtistStatistics {
     public abstract get;
   }
 
+  int TotalCount {
+    public abstract get;
+  }
+
 }
 ```
 
@@ -947,10 +951,6 @@ public interface IUserArtistMap : IStatistics, IUserStatistics, MetaBrainz.Commo
 
 ```cs
 public interface IUserArtistStatistics : IArtistStatistics, IStatistics, IUserStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
-
-  int TotalCount {
-    public abstract get;
-  }
 
 }
 ```


### PR DESCRIPTION
This moves `TotalCount` from `IUserStatistics` to `IArtistStatistics` (technically a breaking change), because the site-wide stats now include it.

[LB-1013](https://tickets.metabrainz.org/browse/LB-1013) seems to have been fixed, so its workaround has been removed.

It also refactors the statistics endpoint code, grouping the methods by statistics type instead of by scope, adding regions for statistics endpoints we don't support yet.