### PR TITLE
Add site-wide artist map support

### DIFF
--- a/MetaBrainz.ListenBrainz/Interfaces/IArtistMap.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IArtistMap.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+using JetBrains.Annotations;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>Information about artist listen counts, grouped by country.</summary>
+[PublicAPI]
+public interface IArtistMap {
+
+  /// <summary>The per-country listen information.</summary>
+  IReadOnlyList<IArtistCountryInfo>? Countries { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/ISiteArtistMap.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ISiteArtistMap.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+using JetBrains.Annotations;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>Information about the number of times artists are listened to, grouped by their country.</summary>
+[PublicAPI]
+public interface ISiteArtistMap : IArtistMap, IStatistics;

--- a/MetaBrainz.ListenBrainz/Interfaces/IUserArtistMap.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IUserArtistMap.cs
@@ -1,14 +1,7 @@
-using System.Collections.Generic;
-
 using JetBrains.Annotations;
 
 namespace MetaBrainz.ListenBrainz.Interfaces;
 
 /// <summary>Information about the number of artists the user has listened to, grouped by their country.</summary>
 [PublicAPI]
-public interface IUserArtistMap : IUserStatistics {
-
-  /// <summary>The per-country listen information.</summary>
-  IReadOnlyList<IArtistCountryInfo>? Countries { get; }
-
-}
+public interface IUserArtistMap : IArtistMap, IUserStatistics;

--- a/MetaBrainz.ListenBrainz/Json/Converters.cs
+++ b/MetaBrainz.ListenBrainz/Json/Converters.cs
@@ -15,6 +15,7 @@ internal static class Converters {
       yield return LatestImportReader.Instance;
       yield return ListenCountReader.Instance;
       yield return PlayingNowReader.Instance;
+      yield return SiteArtistMapReader.Instance;
       yield return SiteArtistStatisticsReader.Instance;
       yield return TokenValidationResultReader.Instance;
       yield return UserArtistMapReader.Instance;

--- a/MetaBrainz.ListenBrainz/Json/Readers/SiteArtistMapReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/SiteArtistMapReader.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+using MetaBrainz.ListenBrainz.Objects;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers;
+
+internal sealed class SiteArtistMapReader : PayloadReader<SiteArtistMap> {
+
+  public static readonly SiteArtistMapReader Instance = new();
+
+  protected override SiteArtistMap ReadPayload(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    IReadOnlyList<IArtistCountryInfo>? countries = null;
+    DateTimeOffset? lastUpdated = null;
+    DateTimeOffset? newestListen = null;
+    DateTimeOffset? oldestListen = null;
+    StatisticsRange? range = null;
+    Dictionary<string, object?>? rest = null;
+    while (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      try {
+        reader.Read();
+        switch (prop) {
+          case "artist_map":
+            countries = reader.ReadList(ArtistCountryInfoReader.Instance, options);
+            break;
+          case "from_ts": {
+            var unixTime = reader.GetOptionalInt64();
+            oldestListen = unixTime is null ? null : DateTimeOffset.FromUnixTimeSeconds(unixTime.Value);
+            break;
+          }
+          case "last_updated":
+            lastUpdated = DateTimeOffset.FromUnixTimeSeconds(reader.GetInt64());
+            break;
+          case "stats_range":
+            range = EnumHelper.ParseStatisticsRange(reader.GetString());
+            if (range == StatisticsRange.Unknown) {
+              goto default; // also register it as an unhandled property
+            }
+            break;
+          case "to_ts": {
+            var unixTime = reader.GetOptionalInt64();
+            newestListen = unixTime is null ? null : DateTimeOffset.FromUnixTimeSeconds(unixTime.Value);
+            break;
+          }
+          default:
+            rest ??= new Dictionary<string, object?>();
+            rest[prop] = reader.GetOptionalObject(options);
+            break;
+        }
+      }
+      catch (Exception e) {
+        throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+      }
+      reader.Read();
+    }
+    if (lastUpdated is null) {
+      throw new JsonException("Expected last-updated timestamp not found or null.");
+    }
+    if (range is null) {
+      throw new JsonException("Expected range not found or null.");
+    }
+    return new SiteArtistMap(lastUpdated.Value, range.Value) {
+      Countries = countries,
+      NewestListen = newestListen,
+      OldestListen = oldestListen,
+      UnhandledProperties = rest,
+    };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.cs
+++ b/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.cs
@@ -65,6 +65,14 @@ public sealed partial class ListenBrainz {
 
   #region /1/stats
 
+  private static IDictionary<string, string> OptionsForGetArtistMap(StatisticsRange? range) {
+    var options = new Dictionary<string, string>(1);
+    if (range is not null) {
+      options.Add("range", range.Value.ToJson());
+    }
+    return options;
+  }
+
   private static IDictionary<string, string> OptionsForGetStatistics(int? count, int? offset, StatisticsRange? range) {
     var options = new Dictionary<string, string>(3);
     if (count is not null) {
@@ -89,23 +97,27 @@ public sealed partial class ListenBrainz {
 
   #region artist-map
 
-  /// <summary>Gets information about the number of artists a user has listened to, grouped by their country.</summary>
-  /// <param name="user">The user for whom the information is requested.</param>
+  /// <summary>Gets information about the number of times artists are listened to, grouped by their country.</summary>
   /// <param name="range">The range of data to include in the statistics.</param>
-  /// <param name="forceRecalculation">Indicates whether recalculation of the data should be requested.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
   /// <returns>The requested information, or <see langword="null"/> if it has not yet been computed for the user.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
-  public Task<IUserArtistMap?> GetArtistMapAsync(string user, StatisticsRange? range = null, bool forceRecalculation = false,
+  public Task<ISiteArtistMap?> GetArtistMapAsync(StatisticsRange? range = null, CancellationToken cancellationToken = default) {
+    var options = ListenBrainz.OptionsForGetArtistMap(range);
+    return this.GetOptionalAsync<ISiteArtistMap, SiteArtistMap>("stats/sitewide/artist-map", options, cancellationToken);
+  }
+
+  /// <summary>Gets information about the number of artists a user has listened to, grouped by their country.</summary>
+  /// <param name="user">The user for whom the information is requested.</param>
+  /// <param name="range">The range of data to include in the statistics.</param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested information, or <see langword="null"/> if it has not yet been computed for the user.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IUserArtistMap?> GetArtistMapAsync(string user, StatisticsRange? range = null,
                                                  CancellationToken cancellationToken = default) {
-    var options = new Dictionary<string, string>(2);
-    if (range is not null) {
-      options.Add("range", range.Value.ToJson());
-    }
-    if (forceRecalculation) {
-      options.Add("force_recalculate", "true");
-    }
+    var options = ListenBrainz.OptionsForGetArtistMap(range);
     return this.GetOptionalAsync<IUserArtistMap, UserArtistMap>($"stats/user/{user}/artist-map", options, cancellationToken);
   }
 

--- a/MetaBrainz.ListenBrainz/MetaBrainz.ListenBrainz.csproj
+++ b/MetaBrainz.ListenBrainz/MetaBrainz.ListenBrainz.csproj
@@ -11,7 +11,7 @@
     <PackageCopyrightYears>2018, 2019, 2020, 2021, 2022, 2023, 2025</PackageCopyrightYears>
     <PackageRepositoryName>MetaBrainz.ListenBrainz</PackageRepositoryName>
     <PackageTags>ListenBrainz music metadata listens audioscrobbler last.fm</PackageTags>
-    <Version>4.0.1-pre</Version>
+    <Version>5.0.0-pre</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/MetaBrainz.ListenBrainz/Objects/SiteArtistMap.cs
+++ b/MetaBrainz.ListenBrainz/Objects/SiteArtistMap.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal sealed class SiteArtistMap(DateTimeOffset lastUpdated, StatisticsRange range)
+  : Statistics(lastUpdated, range), ISiteArtistMap {
+
+  public IReadOnlyList<IArtistCountryInfo>? Countries { get; init; }
+
+}

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -118,7 +118,9 @@ public sealed class ListenBrainz : System.IDisposable {
 
   protected override void Finalize();
 
-  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IUserArtistMap?> GetArtistMapAsync(string user, StatisticsRange? range = default, bool forceRecalculation = false, System.Threading.CancellationToken cancellationToken = default);
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.ISiteArtistMap?> GetArtistMapAsync(StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IUserArtistMap?> GetArtistMapAsync(string user, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
 
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.ISiteArtistStatistics?> GetArtistStatisticsAsync(int? count = default, int? offset = default, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
 
@@ -401,6 +403,18 @@ public interface IArtistInfo : MetaBrainz.Common.Json.IJsonBasedObject {
   }
 
   string Name {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IArtistMap
+
+```cs
+public interface IArtistMap {
+
+  System.Collections.Generic.IReadOnlyList<IArtistCountryInfo>? Countries {
     public abstract get;
   }
 
@@ -803,6 +817,14 @@ public interface IReleaseInfo {
 }
 ```
 
+### Type: ISiteArtistMap
+
+```cs
+public interface ISiteArtistMap : IArtistMap, IStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
+
+}
+```
+
 ### Type: ISiteArtistStatistics
 
 ```cs
@@ -938,11 +960,7 @@ public interface ITrackInfo : MetaBrainz.Common.Json.IJsonBasedObject {
 ### Type: IUserArtistMap
 
 ```cs
-public interface IUserArtistMap : IStatistics, IUserStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
-
-  System.Collections.Generic.IReadOnlyList<IArtistCountryInfo>? Countries {
-    public abstract get;
-  }
+public interface IUserArtistMap : IArtistMap, IStatistics, IUserStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
 
 }
 ```


### PR DESCRIPTION
This adds support for the `/1/stats/sitewide/artist-map` endpoint.

The `Countries` field has been moved from `IUserArtistMap` to a new, separate `IArtistMap` interface; this is a breaking change.

The `forceRecalculation` parameter was dropped from the user-based `GetArtistMapAsync()`; it is not really documented, nor does it seem to have any effect.

The version number has been bumped to 5.0.0-pre (should have already been done for earlier breaking changes).