### PR TITLE
Add site-wide recording statistics support

### DIFF
--- a/MetaBrainz.ListenBrainz/Interfaces/IRecordingStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IRecordingStatistics.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+using JetBrains.Annotations;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>Information about the most-listened recordings ("tracks").</summary>
+[PublicAPI]
+public interface IRecordingStatistics {
+
+  /// <summary>Information about the recordings.</summary>
+  IReadOnlyList<IRecordingInfo>? Recordings { get; }
+
+  /// <summary>The offset of these statistics from the start of the full set.</summary>
+  int? Offset { get; }
+
+  /// <summary>The total number of (distinct) recordings listened to, if available.</summary>
+  int? TotalCount { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/ISiteArtistMap.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ISiteArtistMap.cs
@@ -1,9 +1,9 @@
-﻿using System.Collections.Generic;
-
-using JetBrains.Annotations;
+﻿using JetBrains.Annotations;
 
 namespace MetaBrainz.ListenBrainz.Interfaces;
 
-/// <summary>Information about the number of times artists are listened to, grouped by their country.</summary>
+/// <summary>
+/// Information about the number of times artists are listened to, grouped by their country, across all of ListenBrainz.
+/// </summary>
 [PublicAPI]
 public interface ISiteArtistMap : IArtistMap, IStatistics;

--- a/MetaBrainz.ListenBrainz/Interfaces/ISiteArtistStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ISiteArtistStatistics.cs
@@ -2,6 +2,6 @@ using JetBrains.Annotations;
 
 namespace MetaBrainz.ListenBrainz.Interfaces;
 
-/// <summary>Statistics about how many times particular artists were listened to.</summary>
+/// <summary>Statistics about how many times particular artists were listened to across all of ListenBrainz.</summary>
 [PublicAPI]
 public interface ISiteArtistStatistics : IArtistStatistics, IStatistics;

--- a/MetaBrainz.ListenBrainz/Interfaces/ISiteRecordingStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ISiteRecordingStatistics.cs
@@ -1,0 +1,7 @@
+using JetBrains.Annotations;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>The most-listened recordings ("tracks") across all of ListenBrainz.</summary>
+[PublicAPI]
+public interface ISiteRecordingStatistics : IRecordingStatistics, IStatistics;

--- a/MetaBrainz.ListenBrainz/Interfaces/IUserRecordingStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IUserRecordingStatistics.cs
@@ -6,15 +6,4 @@ namespace MetaBrainz.ListenBrainz.Interfaces;
 
 /// <summary>A user's most-listened recordings ("tracks").</summary>
 [PublicAPI]
-public interface IUserRecordingStatistics : IUserStatistics {
-
-  /// <summary>Information about the recordings.</summary>
-  IReadOnlyList<IRecordingInfo>? Recordings { get; }
-
-  /// <summary>The offset of these statistics from the start of the full set.</summary>
-  int? Offset { get; }
-
-  /// <summary>The total number of (distinct) recordings listened to, if available.</summary>
-  int? TotalCount { get; }
-
-}
+public interface IUserRecordingStatistics : IRecordingStatistics, IUserStatistics;

--- a/MetaBrainz.ListenBrainz/Json/Converters.cs
+++ b/MetaBrainz.ListenBrainz/Json/Converters.cs
@@ -17,6 +17,7 @@ internal static class Converters {
       yield return PlayingNowReader.Instance;
       yield return SiteArtistMapReader.Instance;
       yield return SiteArtistStatisticsReader.Instance;
+      yield return SiteRecordingStatisticsReader.Instance;
       yield return TokenValidationResultReader.Instance;
       yield return UserArtistMapReader.Instance;
       yield return UserArtistStatisticsReader.Instance;

--- a/MetaBrainz.ListenBrainz/Json/Readers/SiteRecordingStatisticsReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/SiteRecordingStatisticsReader.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+using MetaBrainz.ListenBrainz.Objects;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers;
+
+internal sealed class SiteRecordingStatisticsReader : PayloadReader<SiteRecordingStatistics> {
+
+  public static readonly SiteRecordingStatisticsReader Instance = new();
+
+  protected override SiteRecordingStatistics ReadPayload(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    IReadOnlyList<IRecordingInfo>? recordings = null;
+    int? count = null;
+    DateTimeOffset? lastUpdated = null;
+    DateTimeOffset? newestListen = null;
+    int? offset = null;
+    DateTimeOffset? oldestListen = null;
+    StatisticsRange? range = null;
+    int? totalCount = null;
+    Dictionary<string, object?>? rest = null;
+    while (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      try {
+        reader.Read();
+        switch (prop) {
+          case "recordings":
+            recordings = reader.ReadList(RecordingInfoReader.Instance, options);
+            break;
+          case "count":
+            count = reader.GetInt32();
+            break;
+          case "from_ts": {
+            var unixTime = reader.GetOptionalInt64();
+            oldestListen = unixTime is null ? null : DateTimeOffset.FromUnixTimeSeconds(unixTime.Value);
+            break;
+          }
+          case "last_updated":
+            lastUpdated = DateTimeOffset.FromUnixTimeSeconds(reader.GetInt64());
+            break;
+          case "offset":
+            offset = reader.GetInt32();
+            break;
+          case "range":
+            range = EnumHelper.ParseStatisticsRange(reader.GetString());
+            if (range == StatisticsRange.Unknown) {
+              goto default; // also register it as an unhandled property
+            }
+            break;
+          case "to_ts": {
+            var unixTime = reader.GetOptionalInt64();
+            newestListen = unixTime is null ? null : DateTimeOffset.FromUnixTimeSeconds(unixTime.Value);
+            break;
+          }
+          case "total_recording_count":
+            totalCount = reader.GetInt32();
+            break;
+          default:
+            rest ??= new Dictionary<string, object?>();
+            rest[prop] = reader.GetOptionalObject(options);
+            break;
+        }
+      }
+      catch (Exception e) {
+        throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+      }
+      reader.Read();
+    }
+    recordings = PayloadReader<SiteRecordingStatistics>.VerifyPayloadContents(count, recordings);
+    if (lastUpdated is null) {
+      throw new JsonException("Expected last-updated timestamp not found or null.");
+    }
+    if (range is null) {
+      throw new JsonException("Expected range not found or null.");
+    }
+    return new SiteRecordingStatistics(lastUpdated.Value, range.Value) {
+      NewestListen = newestListen,
+      Offset = offset,
+      OldestListen = oldestListen,
+      Recordings = recordings,
+      TotalCount = totalCount,
+      UnhandledProperties = rest,
+    };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.cs
+++ b/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.cs
@@ -232,6 +232,30 @@ public sealed partial class ListenBrainz {
 
   #region recordings
 
+  /// <summary>Gets statistics about the most listened-to recordings ("tracks").</summary>
+  /// <param name="count">
+  /// The (maximum) number of entries to return. If not specified (or <see langword="null"/>), all available information will be
+  /// returned.
+  /// </param>
+  /// <param name="offset">
+  /// The offset (from the start of the results) of the statistics to return. If not specified (or specified as zero or
+  /// <see langword="null"/>), the top most listened-to recordings will be returned.
+  /// </param>
+  /// <param name="range">The range of data to include in the statistics.</param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>
+  /// The requested recording statistics, or <see langword="null"/> if statistics have not yet been computed for the user.
+  /// </returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<ISiteRecordingStatistics?> GetRecordingStatisticsAsync(int? count = null, int? offset = null,
+                                                                     StatisticsRange? range = null,
+                                                                     CancellationToken cancellationToken = default) {
+    var options = ListenBrainz.OptionsForGetStatistics(count, offset, range);
+    return this.GetOptionalAsync<ISiteRecordingStatistics, SiteRecordingStatistics>("stats/sitewide/recordings", options,
+                                                                                    cancellationToken);
+  }
+
   /// <summary>Gets statistics about a user's most listened-to recordings ("tracks").</summary>
   /// <param name="user">The user for whom the statistics are requested.</param>
   /// <param name="count">

--- a/MetaBrainz.ListenBrainz/Objects/SiteRecordingStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Objects/SiteRecordingStatistics.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal sealed class SiteRecordingStatistics(DateTimeOffset lastUpdated, StatisticsRange range)
+  : Statistics(lastUpdated, range), ISiteRecordingStatistics {
+
+  public IReadOnlyList<IRecordingInfo>? Recordings { get; init; }
+
+  public int? Offset { get; init; }
+
+  public int? TotalCount { get; init; }
+
+}

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -150,6 +150,8 @@ public sealed class ListenBrainz : System.IDisposable {
 
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IPlayingNow> GetPlayingNowAsync(string user, System.Threading.CancellationToken cancellationToken = default);
 
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.ISiteRecordingStatistics?> GetRecordingStatisticsAsync(int? count = default, int? offset = default, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
+
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IUserRecordingStatistics?> GetRecordingStatisticsAsync(string user, int? count = default, int? offset = default, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
 
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IUserReleaseGroupStatistics?> GetReleaseGroupStatisticsAsync(string user, int? count = default, int? offset = default, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
@@ -729,6 +731,26 @@ public interface IRecordingInfo {
 }
 ```
 
+### Type: IRecordingStatistics
+
+```cs
+public interface IRecordingStatistics {
+
+  int? Offset {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IRecordingInfo>? Recordings {
+    public abstract get;
+  }
+
+  int? TotalCount {
+    public abstract get;
+  }
+
+}
+```
+
 ### Type: IReleaseGroupInfo
 
 ```cs
@@ -829,6 +851,14 @@ public interface ISiteArtistMap : IArtistMap, IStatistics, MetaBrainz.Common.Jso
 
 ```cs
 public interface ISiteArtistStatistics : IArtistStatistics, IStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
+
+}
+```
+
+### Type: ISiteRecordingStatistics
+
+```cs
+public interface ISiteRecordingStatistics : IRecordingStatistics, IStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
 
 }
 ```
@@ -1000,19 +1030,7 @@ public interface IUserListeningActivity : IStatistics, IUserStatistics, MetaBrai
 ### Type: IUserRecordingStatistics
 
 ```cs
-public interface IUserRecordingStatistics : IStatistics, IUserStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
-
-  int? Offset {
-    public abstract get;
-  }
-
-  System.Collections.Generic.IReadOnlyList<IRecordingInfo>? Recordings {
-    public abstract get;
-  }
-
-  int? TotalCount {
-    public abstract get;
-  }
+public interface IUserRecordingStatistics : IRecordingStatistics, IStatistics, IUserStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
 
 }
 ```


### PR DESCRIPTION
This adds support for the `/1/stats/sitewide/recordings` endpoint.

The properties on `IUserRecordingStatistics` were moved up into a new, separate `IRecordingStatistics` interface (also inherited by the new `ISiteRecordingStatistics` interface).

This is part of the API additions for #59.