### PR TITLE
Add site-wide litening activity support

### DIFF
--- a/MetaBrainz.ListenBrainz/Interfaces/IListeningActivity.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IListeningActivity.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+using JetBrains.Annotations;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>Information about how many listens have been submitted over a period of time.</summary>
+[PublicAPI]
+public interface IListeningActivity {
+
+  /// <summary>The submitted listens.</summary>
+  IReadOnlyList<IListenTimeRange>? Activity { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/ISiteListeningActivity.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ISiteListeningActivity.cs
@@ -1,0 +1,7 @@
+using JetBrains.Annotations;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>Information about how many listens have been submitted over a period of time across all of ListenBrainz.</summary>
+[PublicAPI]
+public interface ISiteListeningActivity : IListeningActivity, IStatistics;

--- a/MetaBrainz.ListenBrainz/Interfaces/IUserListeningActivity.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IUserListeningActivity.cs
@@ -1,14 +1,7 @@
-using System.Collections.Generic;
-
 using JetBrains.Annotations;
 
 namespace MetaBrainz.ListenBrainz.Interfaces;
 
 /// <summary>Information about how many listens a user has submitted over a period of time.</summary>
 [PublicAPI]
-public interface IUserListeningActivity : IUserStatistics {
-
-  /// <summary>The user's listening activity.</summary>
-  IReadOnlyList<IListenTimeRange>? Activity { get; }
-
-}
+public interface IUserListeningActivity : IListeningActivity, IUserStatistics;

--- a/MetaBrainz.ListenBrainz/Json/Converters.cs
+++ b/MetaBrainz.ListenBrainz/Json/Converters.cs
@@ -17,6 +17,7 @@ internal static class Converters {
       yield return PlayingNowReader.Instance;
       yield return SiteArtistMapReader.Instance;
       yield return SiteArtistStatisticsReader.Instance;
+      yield return SiteListeningActivityReader.Instance;
       yield return SiteRecordingStatisticsReader.Instance;
       yield return TokenValidationResultReader.Instance;
       yield return UserArtistMapReader.Instance;

--- a/MetaBrainz.ListenBrainz/Json/Readers/SiteListeningActivityReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/SiteListeningActivityReader.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+using MetaBrainz.ListenBrainz.Objects;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers;
+
+internal sealed class SiteListeningActivityReader : PayloadReader<SiteListeningActivity> {
+
+  public static readonly SiteListeningActivityReader Instance = new();
+
+  protected override SiteListeningActivity ReadPayload(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    IReadOnlyList<IListenTimeRange>? activity = null;
+    DateTimeOffset? lastUpdated = null;
+    DateTimeOffset? newestListen = null;
+    DateTimeOffset? oldestListen = null;
+    StatisticsRange? range = null;
+    Dictionary<string, object?>? rest = null;
+    while (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      try {
+        reader.Read();
+        switch (prop) {
+          case "from_ts": {
+            var unixTime = reader.GetOptionalInt64();
+            oldestListen = unixTime is null ? null : DateTimeOffset.FromUnixTimeSeconds(unixTime.Value);
+            break;
+          }
+          case "last_updated":
+            lastUpdated = DateTimeOffset.FromUnixTimeSeconds(reader.GetInt64());
+            break;
+          case "listening_activity":
+            activity = reader.ReadList(ListenTimeRangeReader.Instance, options);
+            break;
+          case "range":
+            range = EnumHelper.ParseStatisticsRange(reader.GetString());
+            if (range == StatisticsRange.Unknown) {
+              goto default; // also register it as an unhandled property
+            }
+            break;
+          case "to_ts": {
+            var unixTime = reader.GetOptionalInt64();
+            newestListen = unixTime is null ? null : DateTimeOffset.FromUnixTimeSeconds(unixTime.Value);
+            break;
+          }
+          default:
+            rest ??= new Dictionary<string, object?>();
+            rest[prop] = reader.GetOptionalObject(options);
+            break;
+        }
+      }
+      catch (Exception e) {
+        throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+      }
+      reader.Read();
+    }
+    if (lastUpdated is null) {
+      throw new JsonException("Expected last-updated timestamp not found or null.");
+    }
+    if (range is null) {
+      throw new JsonException("Expected range not found or null.");
+    }
+    return new SiteListeningActivity(lastUpdated.Value, range.Value) {
+      Activity = activity,
+      NewestListen = newestListen,
+      OldestListen = oldestListen,
+      UnhandledProperties = rest,
+    };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.cs
+++ b/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.cs
@@ -147,8 +147,9 @@ public sealed partial class ListenBrainz {
   public Task<ISiteArtistStatistics?> GetArtistStatisticsAsync(int? count = null, int? offset = null,
                                                                StatisticsRange? range = null,
                                                                CancellationToken cancellationToken = default) {
+    const string address = "stats/sitewide/artists";
     var options = ListenBrainz.OptionsForGetStatistics(count, offset, range);
-    return this.GetOptionalAsync<ISiteArtistStatistics, SiteArtistStatistics>("stats/sitewide/artists", options, cancellationToken);
+    return this.GetOptionalAsync<ISiteArtistStatistics, SiteArtistStatistics>(address, options, cancellationToken);
   }
 
   /// <summary>Gets statistics about a user's most listened-to artists.</summary>
@@ -210,6 +211,23 @@ public sealed partial class ListenBrainz {
 
   #region listening-activity
 
+  /// <summary>Gets information about how many listens have been submitted over a period of time.</summary>
+  /// <param name="range">
+  /// The range of data to include in the information.<br/>
+  /// If this is unspecified or <see cref="StatisticsRange.AllTime"/>, information is returned about all years with at least one
+  /// recorded listen. Otherwise, information is returned about both the current and the previous range.
+  /// </param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested listening activity.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<ISiteListeningActivity?> GetListeningActivityAsync(StatisticsRange? range = null,
+                                                                 CancellationToken cancellationToken = default) {
+    const string address = "stats/sitewide/listening-activity";
+    var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
+    return this.GetOptionalAsync<ISiteListeningActivity, SiteListeningActivity>(address, options, cancellationToken);
+  }
+
   /// <summary>Gets information about how many listens a user has submitted over a period of time.</summary>
   /// <param name="user">The user for whom the information is requested.</param>
   /// <param name="range">
@@ -251,9 +269,9 @@ public sealed partial class ListenBrainz {
   public Task<ISiteRecordingStatistics?> GetRecordingStatisticsAsync(int? count = null, int? offset = null,
                                                                      StatisticsRange? range = null,
                                                                      CancellationToken cancellationToken = default) {
+    const string address = "stats/sitewide/recordings";
     var options = ListenBrainz.OptionsForGetStatistics(count, offset, range);
-    return this.GetOptionalAsync<ISiteRecordingStatistics, SiteRecordingStatistics>("stats/sitewide/recordings", options,
-                                                                                    cancellationToken);
+    return this.GetOptionalAsync<ISiteRecordingStatistics, SiteRecordingStatistics>(address, options, cancellationToken);
   }
 
   /// <summary>Gets statistics about a user's most listened-to recordings ("tracks").</summary>

--- a/MetaBrainz.ListenBrainz/Objects/SiteListeningActivity.cs
+++ b/MetaBrainz.ListenBrainz/Objects/SiteListeningActivity.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal sealed class SiteListeningActivity(DateTimeOffset lastUpdated, StatisticsRange range)
+  : Statistics(lastUpdated, range), ISiteListeningActivity {
+
+  public IReadOnlyList<IListenTimeRange>? Activity { get; init; }
+
+}

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -132,6 +132,8 @@ public sealed class ListenBrainz : System.IDisposable {
 
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IListenCount> GetListenCountAsync(string user, System.Threading.CancellationToken cancellationToken = default);
 
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.ISiteListeningActivity?> GetListeningActivityAsync(StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
+
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IUserListeningActivity?> GetListeningActivityAsync(string user, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
 
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IFetchedListens> GetListensAfterAsync(string user, System.DateTimeOffset after, int? count = default, int? timeRange = default, System.Threading.CancellationToken cancellationToken = default);
@@ -583,6 +585,18 @@ public interface IListenCount : MetaBrainz.Common.Json.IJsonBasedObject {
 }
 ```
 
+### Type: IListeningActivity
+
+```cs
+public interface IListeningActivity {
+
+  System.Collections.Generic.IReadOnlyList<IListenTimeRange>? Activity {
+    public abstract get;
+  }
+
+}
+```
+
 ### Type: IListenTimeRange
 
 ```cs
@@ -855,6 +869,14 @@ public interface ISiteArtistStatistics : IArtistStatistics, IStatistics, MetaBra
 }
 ```
 
+### Type: ISiteListeningActivity
+
+```cs
+public interface ISiteListeningActivity : IListeningActivity, IStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
+
+}
+```
+
 ### Type: ISiteRecordingStatistics
 
 ```cs
@@ -1018,11 +1040,7 @@ public interface IUserDailyActivity : IStatistics, IUserStatistics, MetaBrainz.C
 ### Type: IUserListeningActivity
 
 ```cs
-public interface IUserListeningActivity : IStatistics, IUserStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
-
-  System.Collections.Generic.IReadOnlyList<IListenTimeRange>? Activity {
-    public abstract get;
-  }
+public interface IUserListeningActivity : IListeningActivity, IStatistics, IUserStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
 
 }
 ```


### PR DESCRIPTION
This adds support for the `/1/stats/sitewide/litening-activity` endpoint.

The properties on `IUserListeningActivity` were moved up into a new, separate `IListeningActivity` interface (also inherited by the new `ISiteListeningActivity` interface); that is a breaking change.

This is part of the API additions for #59.