### PR TITLE
Add site-wide release statistics support

### DIFF
--- a/MetaBrainz.ListenBrainz/Interfaces/IReleaseStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IReleaseStatistics.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+using JetBrains.Annotations;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>The most-listened releases in a particular timeframe.</summary>
+[PublicAPI]
+public interface IReleaseStatistics {
+
+  /// <summary>Information about the releases.</summary>
+  IReadOnlyList<IReleaseInfo>? Releases { get; }
+
+  /// <summary>The offset of these statistics from the start of the full set.</summary>
+  int? Offset { get; }
+
+  /// <summary>The total number of (distinct) releases listened to, if available.</summary>
+  int? TotalCount { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/ISiteReleaseStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ISiteReleaseStatistics.cs
@@ -1,0 +1,7 @@
+using JetBrains.Annotations;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>The most-listened releases across all of ListenBrainz.</summary>
+[PublicAPI]
+public interface ISiteReleaseStatistics : IReleaseStatistics, IStatistics;

--- a/MetaBrainz.ListenBrainz/Interfaces/IUserReleaseStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IUserReleaseStatistics.cs
@@ -1,20 +1,7 @@
-using System.Collections.Generic;
-
 using JetBrains.Annotations;
 
 namespace MetaBrainz.ListenBrainz.Interfaces;
 
 /// <summary>A user's most-listened releases.</summary>
 [PublicAPI]
-public interface IUserReleaseStatistics : IUserStatistics {
-
-  /// <summary>Information about the releases.</summary>
-  IReadOnlyList<IReleaseInfo>? Releases { get; }
-
-  /// <summary>The offset of these statistics from the start of the full set.</summary>
-  int? Offset { get; }
-
-  /// <summary>The total number of (distinct) releases listened to, if available.</summary>
-  int? TotalCount { get; }
-
-}
+public interface IUserReleaseStatistics : IReleaseStatistics, IUserStatistics;

--- a/MetaBrainz.ListenBrainz/Json/Converters.cs
+++ b/MetaBrainz.ListenBrainz/Json/Converters.cs
@@ -19,6 +19,7 @@ internal static class Converters {
       yield return SiteArtistStatisticsReader.Instance;
       yield return SiteListeningActivityReader.Instance;
       yield return SiteRecordingStatisticsReader.Instance;
+      yield return SiteReleaseStatisticsReader.Instance;
       yield return TokenValidationResultReader.Instance;
       yield return UserArtistMapReader.Instance;
       yield return UserArtistStatisticsReader.Instance;

--- a/MetaBrainz.ListenBrainz/Json/Readers/SiteReleaseStatisticsReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/SiteReleaseStatisticsReader.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+using MetaBrainz.ListenBrainz.Objects;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers;
+
+internal sealed class SiteReleaseStatisticsReader : PayloadReader<SiteReleaseStatistics> {
+
+  public static readonly SiteReleaseStatisticsReader Instance = new();
+
+  protected override SiteReleaseStatistics ReadPayload(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    IReadOnlyList<IReleaseInfo>? releases = null;
+    int? count = null;
+    DateTimeOffset? lastUpdated = null;
+    DateTimeOffset? newestListen = null;
+    int? offset = null;
+    DateTimeOffset? oldestListen = null;
+    StatisticsRange? range = null;
+    int? totalCount = null;
+    Dictionary<string, object?>? rest = null;
+    while (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      try {
+        reader.Read();
+        switch (prop) {
+          case "releases":
+            releases = reader.ReadList(ReleaseInfoReader.Instance, options);
+            break;
+          case "count":
+            count = reader.GetInt32();
+            break;
+          case "from_ts": {
+            var unixTime = reader.GetOptionalInt64();
+            oldestListen = unixTime is null ? null : DateTimeOffset.FromUnixTimeSeconds(unixTime.Value);
+            break;
+          }
+          case "last_updated":
+            lastUpdated = DateTimeOffset.FromUnixTimeSeconds(reader.GetInt64());
+            break;
+          case "offset":
+            offset = reader.GetInt32();
+            break;
+          case "range":
+            range = EnumHelper.ParseStatisticsRange(reader.GetString());
+            if (range == StatisticsRange.Unknown) {
+              goto default; // also register it as an unhandled property
+            }
+            break;
+          case "to_ts": {
+            var unixTime = reader.GetOptionalInt64();
+            newestListen = unixTime is null ? null : DateTimeOffset.FromUnixTimeSeconds(unixTime.Value);
+            break;
+          }
+          case "total_release_count":
+            totalCount = reader.GetInt32();
+            break;
+          default:
+            rest ??= new Dictionary<string, object?>();
+            rest[prop] = reader.GetOptionalObject(options);
+            break;
+        }
+      }
+      catch (Exception e) {
+        throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+      }
+      reader.Read();
+    }
+    releases = PayloadReader<SiteReleaseStatistics>.VerifyPayloadContents(count, releases);
+    if (lastUpdated is null) {
+      throw new JsonException("Expected last-updated timestamp not found or null.");
+    }
+    if (range is null) {
+      throw new JsonException("Expected range not found or null.");
+    }
+    return new SiteReleaseStatistics(lastUpdated.Value, range.Value) {
+      NewestListen = newestListen,
+      Offset = offset,
+      OldestListen = oldestListen,
+      Releases = releases,
+      TotalCount = totalCount,
+      UnhandledProperties = rest,
+    };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.cs
+++ b/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.cs
@@ -97,7 +97,9 @@ public sealed partial class ListenBrainz {
 
   #region artist-map
 
-  /// <summary>Gets information about the number of times artists are listened to, grouped by their country.</summary>
+  /// <summary>
+  /// Gets information about the number of times artists are listened to across all of ListenBrainz, grouped by their country.
+  /// </summary>
   /// <param name="range">The range of data to include in the statistics.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
   /// <returns>The requested information, or <see langword="null"/> if it has not yet been computed for the user.</returns>
@@ -125,7 +127,7 @@ public sealed partial class ListenBrainz {
 
   #region artists
 
-  /// <summary>Gets statistics about the most listened-to artists.</summary>
+  /// <summary>Gets statistics about the most listened-to artists across all of ListenBrainz.</summary>
   /// <param name="count">
   /// The (maximum) number of entries to return. If not specified (or <see langword="null"/>), all available information will be
   /// returned.
@@ -211,7 +213,7 @@ public sealed partial class ListenBrainz {
 
   #region listening-activity
 
-  /// <summary>Gets information about how many listens have been submitted over a period of time.</summary>
+  /// <summary>Gets information about how many listens have been submitted across to ListenBrainz over a period of time.</summary>
   /// <param name="range">
   /// The range of data to include in the information.<br/>
   /// If this is unspecified or <see cref="StatisticsRange.AllTime"/>, information is returned about all years with at least one
@@ -228,7 +230,7 @@ public sealed partial class ListenBrainz {
     return this.GetOptionalAsync<ISiteListeningActivity, SiteListeningActivity>(address, options, cancellationToken);
   }
 
-  /// <summary>Gets information about how many listens a user has submitted over a period of time.</summary>
+  /// <summary>Gets information about how many listens a user has submitted to ListenBrainz over a period of time.</summary>
   /// <param name="user">The user for whom the information is requested.</param>
   /// <param name="range">
   /// The range of data to include in the information.<br/>
@@ -250,7 +252,7 @@ public sealed partial class ListenBrainz {
 
   #region recordings
 
-  /// <summary>Gets statistics about the most listened-to recordings ("tracks").</summary>
+  /// <summary>Gets statistics about the most listened-to recordings ("tracks") across all of ListenBrainz.</summary>
   /// <param name="count">
   /// The (maximum) number of entries to return. If not specified (or <see langword="null"/>), all available information will be
   /// returned.
@@ -331,6 +333,30 @@ public sealed partial class ListenBrainz {
   #endregion
 
   #region releases
+
+  /// <summary>Gets statistics about the most listened-to releases ("albums") across all of ListenBrainz.</summary>
+  /// <param name="count">
+  /// The (maximum) number of entries to return. If not specified (or <see langword="null"/>), all available information will be
+  /// returned.
+  /// </param>
+  /// <param name="offset">
+  /// The offset (from the start of the results) of the statistics to return. If not specified (or specified as zero or
+  /// <see langword="null"/>), the top most listened-to releases will be returned.
+  /// </param>
+  /// <param name="range">The range of data to include in the statistics.</param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>
+  /// The requested releases statistics, or <see langword="null"/> if statistics have not yet been computed for the user.
+  /// </returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<ISiteReleaseStatistics?> GetReleaseStatisticsAsync(int? count = null, int? offset = null,
+                                                                 StatisticsRange? range = null,
+                                                                 CancellationToken cancellationToken = default) {
+    const string address = "stats/sitewide/releases";
+    var options = ListenBrainz.OptionsForGetStatistics(count, offset, range);
+    return this.GetOptionalAsync<ISiteReleaseStatistics, SiteReleaseStatistics>(address, options, cancellationToken);
+  }
 
   /// <summary>Gets statistics about a user's most listened-to releases ("albums").</summary>
   /// <param name="user">The user for whom the statistics are requested.</param>

--- a/MetaBrainz.ListenBrainz/Objects/SiteReleaseStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Objects/SiteReleaseStatistics.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal sealed class SiteReleaseStatistics(DateTimeOffset lastUpdated, StatisticsRange range)
+  : Statistics(lastUpdated, range), ISiteReleaseStatistics {
+
+  public IReadOnlyList<IReleaseInfo>? Releases { get; init; }
+
+  public int? Offset { get; init; }
+
+  public int? TotalCount { get; init; }
+
+}

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -158,6 +158,8 @@ public sealed class ListenBrainz : System.IDisposable {
 
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IUserReleaseGroupStatistics?> GetReleaseGroupStatisticsAsync(string user, int? count = default, int? offset = default, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
 
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.ISiteReleaseStatistics?> GetReleaseStatisticsAsync(int? count = default, int? offset = default, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
+
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IUserReleaseStatistics?> GetReleaseStatisticsAsync(string user, int? count = default, int? offset = default, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
 
   public System.Threading.Tasks.Task ImportListensAsync(params MetaBrainz.ListenBrainz.Interfaces.ISubmittedListen[] listens);
@@ -853,6 +855,26 @@ public interface IReleaseInfo {
 }
 ```
 
+### Type: IReleaseStatistics
+
+```cs
+public interface IReleaseStatistics {
+
+  int? Offset {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IReleaseInfo>? Releases {
+    public abstract get;
+  }
+
+  int? TotalCount {
+    public abstract get;
+  }
+
+}
+```
+
 ### Type: ISiteArtistMap
 
 ```cs
@@ -881,6 +903,14 @@ public interface ISiteListeningActivity : IListeningActivity, IStatistics, MetaB
 
 ```cs
 public interface ISiteRecordingStatistics : IRecordingStatistics, IStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
+
+}
+```
+
+### Type: ISiteReleaseStatistics
+
+```cs
+public interface ISiteReleaseStatistics : IReleaseStatistics, IStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
 
 }
 ```
@@ -1076,19 +1106,7 @@ public interface IUserReleaseGroupStatistics : IStatistics, IUserStatistics, Met
 ### Type: IUserReleaseStatistics
 
 ```cs
-public interface IUserReleaseStatistics : IStatistics, IUserStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
-
-  int? Offset {
-    public abstract get;
-  }
-
-  System.Collections.Generic.IReadOnlyList<IReleaseInfo>? Releases {
-    public abstract get;
-  }
-
-  int? TotalCount {
-    public abstract get;
-  }
+public interface IUserReleaseStatistics : IReleaseStatistics, IStatistics, IUserStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
 
 }
 ```


### PR DESCRIPTION
This adds support for the `/1/stats/sitewide/releases` endpoint.

The properties on `IUserReleaseStatistics` were moved up into a new, separate `IReleaseStatistics` interface (also inherited by the new `ISiteReleaseStatistics` interface); that is a breaking change.

This is part of the API additions for #59.