### PR TITLE
Add listener statistics (artist and RG)

### DIFF
--- a/MetaBrainz.ListenBrainz/Interfaces/IArtistListeners.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IArtistListeners.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>Information about an artist's top listeners.</summary>
+public interface IArtistListeners : IListenerInfo, IStatistics {
+
+  /// <summary>The MusicBrainz ID for the artist.</summary>
+  Guid Id { get; }
+
+  /// <summary>The artist's name.</summary>
+  string Name { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/IListenerInfo.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IListenerInfo.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>Information about the listeners for an item.</summary>
+public interface IListenerInfo {
+
+  /// <summary>The top listeners for this item.</summary>
+  IReadOnlyList<ITopListener> TopListeners { get; }
+
+  /// <summary>The total number of listens for this item.</summary>
+  int TotalListens { get; }
+
+  /// <summary>The total number of listeners for this item.</summary>
+  int TotalListeners { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/IReleaseGroupListeners.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IReleaseGroupListeners.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>Information about a release group's top listeners.</summary>
+public interface IReleaseGroupListeners : IListenerInfo, IStatistics {
+
+  /// <summary>The MusicBrainz IDs for the release group's artist(s), if available.</summary>
+  IReadOnlyList<Guid>? ArtistIds { get; }
+
+  /// <summary>The release group's artist's name, if available.</summary>
+  string? ArtistName { get; }
+
+  /// <summary>The internal ID for the release group in the CoverArt Archive.</summary>
+  long? CoverArtId { get; }
+
+  /// <summary>The MusicBrainz ID for the release group in the CoverArt Archive.</summary>
+  Guid? CoverArtReleaseGroupId { get; }
+
+  /// <summary>The MusicBrainz ID for the release group.</summary>
+  Guid Id { get; }
+
+  /// <summary>The release group's name.</summary>
+  string Name { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/ITopListener.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ITopListener.cs
@@ -1,0 +1,17 @@
+﻿using MetaBrainz.Common.Json;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>Information about a top listener.</summary>
+public interface ITopListener : IJsonBasedObject {
+
+  /// <summary>The listen count.</summary>
+  int ListenCount { get; }
+
+  /// <summary>The name of the listener.</summary>
+  /// <remarks>
+  /// When multiple users have the same listen count, this will contain all their names, separated by a comma and a blank.
+  /// </remarks>
+  string UserName { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Converters.cs
+++ b/MetaBrainz.ListenBrainz/Json/Converters.cs
@@ -10,11 +10,13 @@ internal static class Converters {
 
   public static IEnumerable<JsonConverter> Readers {
     get {
+      yield return ArtistListenersReader.Instance;
       yield return ErrorInfoReader.Instance;
       yield return FetchedListensReader.Instance;
       yield return LatestImportReader.Instance;
       yield return ListenCountReader.Instance;
       yield return PlayingNowReader.Instance;
+      yield return ReleaseGroupListenersReader.Instance;
       yield return SiteArtistMapReader.Instance;
       yield return SiteArtistStatisticsReader.Instance;
       yield return SiteListeningActivityReader.Instance;

--- a/MetaBrainz.ListenBrainz/Json/Readers/FetchedListensReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/FetchedListensReader.cs
@@ -50,18 +50,18 @@ internal sealed class FetchedListensReader : PayloadReader<FetchedListens> {
       }
       reader.Read();
     }
-    listens = PayloadReader<FetchedListens>.VerifyPayloadContents(count, listens);
-    if (user is null) {
-      throw new JsonException("Expected user id not found or null.");
-    }
     if (newest is null) {
       throw new JsonException("Expected latest-listen timestamp not found or null.");
     }
     if (oldest is null) {
       throw new JsonException("Expected oldest-listen timestamp not found or null.");
     }
-    return new FetchedListens(listens, newest.Value, oldest.Value, user) {
-      UnhandledProperties = rest
+    return new FetchedListens {
+      Listens = listens.VerifyPayloadContents(count),
+      Newest = DateTimeOffset.FromUnixTimeSeconds(newest.Value),
+      Oldest = DateTimeOffset.FromUnixTimeSeconds(oldest.Value),
+      UnhandledProperties = rest,
+      User = user ?? throw new JsonException("Expected user id not found or null."),
     };
   }
 

--- a/MetaBrainz.ListenBrainz/Json/Readers/Helpers.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/Helpers.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Text.Json;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers;
+
+internal static class Helpers {
+
+  public static IReadOnlyList<TItem> VerifyPayloadContents<TItem>(this IReadOnlyList<TItem>? items, int? count) {
+    if (count is null) {
+      throw new JsonException("Expected payload item count not found or null.");
+    }
+    var n = items?.Count ?? 0;
+    if (n != count.Value) {
+      throw new JsonException($"The size of the list of items ({n}) does not match the reported item count ({count}).");
+    }
+    // treat missing/null the same as []
+    return items ?? [ ];
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Readers/PayloadReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/PayloadReader.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using System.Text.Json;
 
 using MetaBrainz.Common.Json.Converters;
@@ -25,17 +24,5 @@ internal abstract class PayloadReader<T> : ObjectReader<T> {
   }
 
   protected abstract T ReadPayload(ref Utf8JsonReader reader, JsonSerializerOptions options);
-
-  protected static IReadOnlyList<TItem> VerifyPayloadContents<TItem>(int? count, IReadOnlyList<TItem>? items) {
-    if (count is null) {
-      throw new JsonException("Expected payload item count not found or null.");
-    }
-    var n = items?.Count ?? 0;
-    if (n != count.Value) {
-      throw new JsonException($"The size of the list of items ({n}) does not match the reported item count ({count}).");
-    }
-    // treat missing/null the same as []
-    return items ?? [ ];
-  }
 
 }

--- a/MetaBrainz.ListenBrainz/Json/Readers/ReleaseGroupListenersReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ReleaseGroupListenersReader.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+using MetaBrainz.ListenBrainz.Objects;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers;
+
+internal sealed class ReleaseGroupListenersReader : PayloadReader<ReleaseGroupListeners> {
+
+  public static readonly ReleaseGroupListenersReader Instance = new();
+
+  protected override ReleaseGroupListeners ReadPayload(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    IReadOnlyList<Guid>? artistMbids = null;
+    string? artistName = null;
+    long? caaId = null;
+    Guid? caaRelease = null;
+    Guid? mbid = null;
+    string? name = null;
+    DateTimeOffset? lastUpdated = null;
+    DateTimeOffset? newestListen = null;
+    DateTimeOffset? oldestListen = null;
+    StatisticsRange? range = null;
+    Dictionary<string, object?>? rest = null;
+    IReadOnlyList<ITopListener>? topListeners = null;
+    int? totalListeners = null;
+    int? totalListens = null;
+    while (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      try {
+        reader.Read();
+        switch (prop) {
+          case "artist_mbids":
+            artistMbids = reader.ReadList<Guid>(options);
+            break;
+          case "artist_name":
+            artistName = reader.GetString();
+            break;
+          case "caa_id":
+            caaId = reader.GetOptionalInt64();
+            break;
+          case "caa_release_mbid":
+            caaRelease = reader.GetOptionalGuid();
+            break;
+          case "from_ts": {
+            var unixTime = reader.GetOptionalInt64();
+            oldestListen = unixTime is null ? null : DateTimeOffset.FromUnixTimeSeconds(unixTime.Value);
+            break;
+          }
+          case "last_updated":
+            lastUpdated = DateTimeOffset.FromUnixTimeSeconds(reader.GetInt64());
+            break;
+          case "listeners":
+            topListeners = reader.ReadList(TopListenerReader.Instance, options);
+            break;
+          case "release_group_mbid":
+            mbid = reader.GetOptionalGuid();
+            break;
+          case "release_group_name":
+            name = reader.GetString();
+            break;
+          case "stats_range":
+            range = EnumHelper.ParseStatisticsRange(reader.GetString());
+            if (range == StatisticsRange.Unknown) {
+              goto default; // also register it as an unhandled property
+            }
+            break;
+          case "to_ts": {
+            var unixTime = reader.GetOptionalInt64();
+            newestListen = unixTime is null ? null : DateTimeOffset.FromUnixTimeSeconds(unixTime.Value);
+            break;
+          }
+          case "total_listen_count":
+            totalListens = reader.GetInt32();
+            break;
+          case "total_user_count":
+            totalListeners = reader.GetInt32();
+            break;
+          default:
+            rest ??= new Dictionary<string, object?>();
+            rest[prop] = reader.GetOptionalObject(options);
+            break;
+        }
+      }
+      catch (Exception e) {
+        throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+      }
+      reader.Read();
+    }
+    return new ReleaseGroupListeners {
+      ArtistIds = artistMbids,
+      ArtistName = artistName,
+      CoverArtId = caaId,
+      CoverArtReleaseGroupId = caaRelease,
+      Id = mbid ?? throw new JsonException("Expected release group MBID not found or null."),
+      LastUpdated = lastUpdated ?? throw new JsonException("Expected last-updated timestamp not found or null."),
+      Name = name ?? throw new JsonException("Expected release group name not found or null."),
+      NewestListen = newestListen,
+      OldestListen = oldestListen,
+      Range = range ?? throw new JsonException("Expected range not found or null."),
+      TopListeners = topListeners ?? throw new JsonException("Expected list of top listeners not found or null."),
+      TotalListeners = totalListeners ?? throw new JsonException("Expected total listener count not found or null."),
+      TotalListens = totalListens ?? throw new JsonException("Expected total listener count not found or null."),
+      UnhandledProperties = rest,
+    };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Readers/SiteArtistMapReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/SiteArtistMapReader.cs
@@ -57,16 +57,12 @@ internal sealed class SiteArtistMapReader : PayloadReader<SiteArtistMap> {
       }
       reader.Read();
     }
-    if (lastUpdated is null) {
-      throw new JsonException("Expected last-updated timestamp not found or null.");
-    }
-    if (range is null) {
-      throw new JsonException("Expected range not found or null.");
-    }
-    return new SiteArtistMap(lastUpdated.Value, range.Value) {
+    return new SiteArtistMap {
       Countries = countries,
+      LastUpdated = lastUpdated ?? throw new JsonException("Expected last-updated timestamp not found or null."),
       NewestListen = newestListen,
       OldestListen = oldestListen,
+      Range = range ?? throw new JsonException("Expected range not found or null."),
       UnhandledProperties = rest,
     };
   }

--- a/MetaBrainz.ListenBrainz/Json/Readers/SiteArtistStatisticsReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/SiteArtistStatisticsReader.cs
@@ -69,23 +69,15 @@ internal sealed class SiteArtistStatisticsReader : PayloadReader<SiteArtistStati
       }
       reader.Read();
     }
-    artists = PayloadReader<SiteArtistStatistics>.VerifyPayloadContents(count, artists);
-    if (lastUpdated is null) {
-      throw new JsonException("Expected last-updated timestamp not found or null.");
-    }
-    if (offset is null) {
-      throw new JsonException("Expected offset not found or null.");
-    }
-    if (range is null) {
-      throw new JsonException("Expected range not found or null.");
-    }
-    if (totalCount is null) {
-      throw new JsonException("Expected total count not found or null.");
-    }
-    return new SiteArtistStatistics(count ?? 0, totalCount.Value, lastUpdated.Value, offset.Value, range.Value) {
-      Artists = artists,
+    return new SiteArtistStatistics {
+      Artists = artists.VerifyPayloadContents(count),
+      Count = count ?? 0,
+      LastUpdated = lastUpdated ?? throw new JsonException("Expected last-updated timestamp not found or null."),
       NewestListen = newestListen,
+      Offset = offset ?? throw new JsonException("Expected offset not found or null."),
       OldestListen = oldestListen,
+      Range = range ?? throw new JsonException("Expected range not found or null."),
+      TotalCount = totalCount ?? throw new JsonException("Expected total count not found or null."),
       UnhandledProperties = rest,
     };
   }

--- a/MetaBrainz.ListenBrainz/Json/Readers/SiteListeningActivityReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/SiteListeningActivityReader.cs
@@ -57,16 +57,12 @@ internal sealed class SiteListeningActivityReader : PayloadReader<SiteListeningA
       }
       reader.Read();
     }
-    if (lastUpdated is null) {
-      throw new JsonException("Expected last-updated timestamp not found or null.");
-    }
-    if (range is null) {
-      throw new JsonException("Expected range not found or null.");
-    }
-    return new SiteListeningActivity(lastUpdated.Value, range.Value) {
+    return new SiteListeningActivity {
       Activity = activity,
+      LastUpdated = lastUpdated ?? throw new JsonException("Expected last-updated timestamp not found or null."),
       NewestListen = newestListen,
       OldestListen = oldestListen,
+      Range = range ?? throw new JsonException("Expected range not found or null."),
       UnhandledProperties = rest,
     };
   }

--- a/MetaBrainz.ListenBrainz/Json/Readers/SiteRecordingStatisticsReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/SiteRecordingStatisticsReader.cs
@@ -69,18 +69,13 @@ internal sealed class SiteRecordingStatisticsReader : PayloadReader<SiteRecordin
       }
       reader.Read();
     }
-    recordings = PayloadReader<SiteRecordingStatistics>.VerifyPayloadContents(count, recordings);
-    if (lastUpdated is null) {
-      throw new JsonException("Expected last-updated timestamp not found or null.");
-    }
-    if (range is null) {
-      throw new JsonException("Expected range not found or null.");
-    }
-    return new SiteRecordingStatistics(lastUpdated.Value, range.Value) {
+    return new SiteRecordingStatistics {
+      LastUpdated = lastUpdated ?? throw new JsonException("Expected last-updated timestamp not found or null."),
       NewestListen = newestListen,
       Offset = offset,
       OldestListen = oldestListen,
-      Recordings = recordings,
+      Range = range ?? throw new JsonException("Expected range not found or null."),
+      Recordings = recordings.VerifyPayloadContents(count),
       TotalCount = totalCount,
       UnhandledProperties = rest,
     };

--- a/MetaBrainz.ListenBrainz/Json/Readers/SiteReleaseGroupStatisticsReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/SiteReleaseGroupStatisticsReader.cs
@@ -69,18 +69,13 @@ internal sealed class SiteReleaseGroupStatisticsReader : PayloadReader<SiteRelea
       }
       reader.Read();
     }
-    releaseGroups = PayloadReader<SiteReleaseGroupStatistics>.VerifyPayloadContents(count, releaseGroups);
-    if (lastUpdated is null) {
-      throw new JsonException("Expected last-updated timestamp not found or null.");
-    }
-    if (range is null) {
-      throw new JsonException("Expected range not found or null.");
-    }
-    return new SiteReleaseGroupStatistics(lastUpdated.Value, range.Value) {
+    return new SiteReleaseGroupStatistics {
+      LastUpdated = lastUpdated ?? throw new JsonException("Expected last-updated timestamp not found or null."),
       NewestListen = newestListen,
       Offset = offset,
       OldestListen = oldestListen,
-      ReleaseGroups = releaseGroups,
+      Range = range ?? throw new JsonException("Expected range not found or null."),
+      ReleaseGroups = releaseGroups.VerifyPayloadContents(count),
       TotalCount = totalCount,
       UnhandledProperties = rest,
     };

--- a/MetaBrainz.ListenBrainz/Json/Readers/SiteReleaseStatisticsReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/SiteReleaseStatisticsReader.cs
@@ -69,18 +69,13 @@ internal sealed class SiteReleaseStatisticsReader : PayloadReader<SiteReleaseSta
       }
       reader.Read();
     }
-    releases = PayloadReader<SiteReleaseStatistics>.VerifyPayloadContents(count, releases);
-    if (lastUpdated is null) {
-      throw new JsonException("Expected last-updated timestamp not found or null.");
-    }
-    if (range is null) {
-      throw new JsonException("Expected range not found or null.");
-    }
-    return new SiteReleaseStatistics(lastUpdated.Value, range.Value) {
+    return new SiteReleaseStatistics {
+      LastUpdated = lastUpdated ?? throw new JsonException("Expected last-updated timestamp not found or null."),
       NewestListen = newestListen,
       Offset = offset,
       OldestListen = oldestListen,
-      Releases = releases,
+      Range = range ?? throw new JsonException("Expected range not found or null."),
+      Releases = releases.VerifyPayloadContents(count),
       TotalCount = totalCount,
       UnhandledProperties = rest,
     };

--- a/MetaBrainz.ListenBrainz/Json/Readers/TopListenerReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/TopListenerReader.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.Common.Json.Converters;
+using MetaBrainz.ListenBrainz.Objects;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers;
+
+internal class TopListenerReader : ObjectReader<TopListener> {
+
+  public static readonly TopListenerReader Instance = new();
+
+  protected override TopListener ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    int? listenCount = null;
+    string? name = null;
+    Dictionary<string, object?>? rest = null;
+    while (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      try {
+        reader.Read();
+        switch (prop) {
+          case "user_name":
+            name = reader.GetString();
+            break;
+          case "listen_count":
+            listenCount = reader.GetInt32();
+            break;
+          default:
+            rest ??= new Dictionary<string, object?>();
+            rest[prop] = reader.GetOptionalObject(options);
+            break;
+        }
+      }
+      catch (Exception e) {
+        throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+      }
+      reader.Read();
+    }
+    return new TopListener {
+      ListenCount = listenCount ?? throw new JsonException("Expected listen count not found or null."),
+      UserName = name ?? throw new JsonException("Expected user name not found or null."),
+      UnhandledProperties = rest,
+    };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Readers/UserArtistStatisticsReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/UserArtistStatisticsReader.cs
@@ -73,27 +73,18 @@ internal sealed class UserArtistStatisticsReader : PayloadReader<UserArtistStati
       }
       reader.Read();
     }
-    artists = PayloadReader<UserArtistStatistics>.VerifyPayloadContents(count, artists);
-    if (lastUpdated is null) {
-      throw new JsonException("Expected last-updated timestamp not found or null.");
-    }
-    if (offset is null) {
-      throw new JsonException("Expected offset not found or null.");
-    }
-    if (range is null) {
-      throw new JsonException("Expected range not found or null.");
-    }
-    if (totalCount is null) {
-      throw new JsonException("Expected total count not found or null.");
-    }
-    if (user is null) {
-      throw new JsonException("Expected user id not found or null.");
-    }
-    return new UserArtistStatistics(count ?? 0, totalCount.Value, lastUpdated.Value, offset.Value, range.Value, user) {
+    artists = artists.VerifyPayloadContents(count);
+    return new UserArtistStatistics {
       Artists = artists,
+      Count = count ?? 0,
+      LastUpdated = lastUpdated ?? throw new JsonException("Expected last-updated timestamp not found or null."),
       NewestListen = newestListen,
+      Offset = offset ?? throw new JsonException("Expected offset not found or null."),
       OldestListen = oldestListen,
+      Range = range ?? throw new JsonException("Expected range not found or null."),
+      TotalCount = totalCount ?? throw new JsonException("Expected total count not found or null."),
       UnhandledProperties = rest,
+      User = user ?? throw new JsonException("Expected user id not found or null."),
     };
   }
 

--- a/MetaBrainz.ListenBrainz/Json/Readers/UserDailyActivityReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/UserDailyActivityReader.cs
@@ -61,20 +61,14 @@ internal sealed class UserDailyActivityReader : PayloadReader<UserDailyActivity>
       }
       reader.Read();
     }
-    if (lastUpdated is null) {
-      throw new JsonException("Expected last-updated timestamp not found or null.");
-    }
-    if (range is null) {
-      throw new JsonException("Expected range not found or null.");
-    }
-    if (user is null) {
-      throw new JsonException("Expected user id not found or null.");
-    }
-    return new UserDailyActivity(lastUpdated.Value, range.Value, user) {
+    return new UserDailyActivity {
       Activity = activity,
+      LastUpdated = lastUpdated ?? throw new JsonException("Expected last-updated timestamp not found or null."),
       NewestListen = newestListen,
       OldestListen = oldestListen,
+      Range = range ?? throw new JsonException("Expected range not found or null."),
       UnhandledProperties = rest,
+      User = user ?? throw new JsonException("Expected user id not found or null."),
     };
   }
 

--- a/MetaBrainz.ListenBrainz/Json/Readers/UserListeningActivityReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/UserListeningActivityReader.cs
@@ -61,20 +61,14 @@ internal sealed class UserListeningActivityReader : PayloadReader<UserListeningA
       }
       reader.Read();
     }
-    if (lastUpdated is null) {
-      throw new JsonException("Expected last-updated timestamp not found or null.");
-    }
-    if (range is null) {
-      throw new JsonException("Expected range not found or null.");
-    }
-    if (user is null) {
-      throw new JsonException("Expected user id not found or null.");
-    }
-    return new UserListeningActivity(lastUpdated.Value, range.Value, user) {
+    return new UserListeningActivity {
       Activity = activity,
+      LastUpdated = lastUpdated ?? throw new JsonException("Expected last-updated timestamp not found or null."),
       NewestListen = newestListen,
       OldestListen = oldestListen,
+      Range = range ?? throw new JsonException("Expected range not found or null."),
       UnhandledProperties = rest,
+      User = user ?? throw new JsonException("Expected user id not found or null."),
     };
   }
 

--- a/MetaBrainz.ListenBrainz/Json/Readers/UserRecordingStatisticsReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/UserRecordingStatisticsReader.cs
@@ -73,23 +73,16 @@ internal sealed class UserRecordingStatisticsReader : PayloadReader<UserRecordin
       }
       reader.Read();
     }
-    recordings = PayloadReader<UserRecordingStatistics>.VerifyPayloadContents(count, recordings);
-    if (lastUpdated is null) {
-      throw new JsonException("Expected last-updated timestamp not found or null.");
-    }
-    if (range is null) {
-      throw new JsonException("Expected range not found or null.");
-    }
-    if (user is null) {
-      throw new JsonException("Expected user id not found or null.");
-    }
-    return new UserRecordingStatistics(lastUpdated.Value, range.Value, user) {
+    return new UserRecordingStatistics{
+      LastUpdated = lastUpdated ?? throw new JsonException("Expected last-updated timestamp not found or null."),
       NewestListen = newestListen,
       Offset = offset,
       OldestListen = oldestListen,
-      Recordings = recordings,
+      Range = range ?? throw new JsonException("Expected range not found or null."),
+      Recordings = recordings.VerifyPayloadContents(count),
       TotalCount = totalCount,
       UnhandledProperties = rest,
+      User = user ?? throw new JsonException("Expected user id not found or null."),
     };
   }
 

--- a/MetaBrainz.ListenBrainz/Json/Readers/UserReleaseGroupStatisticsReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/UserReleaseGroupStatisticsReader.cs
@@ -73,23 +73,16 @@ internal sealed class UserReleaseGroupStatisticsReader : PayloadReader<UserRelea
       }
       reader.Read();
     }
-    releaseGroups = PayloadReader<UserReleaseGroupStatistics>.VerifyPayloadContents(count, releaseGroups);
-    if (lastUpdated is null) {
-      throw new JsonException("Expected last-updated timestamp not found or null.");
-    }
-    if (range is null) {
-      throw new JsonException("Expected range not found or null.");
-    }
-    if (user is null) {
-      throw new JsonException("Expected user id not found or null.");
-    }
-    return new UserReleaseGroupStatistics(lastUpdated.Value, range.Value, user) {
+    return new UserReleaseGroupStatistics {
+      LastUpdated = lastUpdated ?? throw new JsonException("Expected last-updated timestamp not found or null."),
       NewestListen = newestListen,
       Offset = offset,
       OldestListen = oldestListen,
-      ReleaseGroups = releaseGroups,
+      Range = range ?? throw new JsonException("Expected range not found or null."),
+      ReleaseGroups = releaseGroups.VerifyPayloadContents(count),
       TotalCount = totalCount,
       UnhandledProperties = rest,
+      User = user ?? throw new JsonException("Expected user id not found or null."),
     };
   }
 

--- a/MetaBrainz.ListenBrainz/Json/Readers/UserReleaseStatisticsReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/UserReleaseStatisticsReader.cs
@@ -73,23 +73,16 @@ internal sealed class UserReleaseStatisticsReader : PayloadReader<UserReleaseSta
       }
       reader.Read();
     }
-    releases = PayloadReader<UserReleaseStatistics>.VerifyPayloadContents(count, releases);
-    if (lastUpdated is null) {
-      throw new JsonException("Expected last-updated timestamp not found or null.");
-    }
-    if (range is null) {
-      throw new JsonException("Expected range not found or null.");
-    }
-    if (user is null) {
-      throw new JsonException("Expected user id not found or null.");
-    }
-    return new UserReleaseStatistics(lastUpdated.Value, range.Value, user) {
+    return new UserReleaseStatistics {
+      LastUpdated = lastUpdated ?? throw new JsonException("Expected last-updated timestamp not found or null."),
       NewestListen = newestListen,
       Offset = offset,
       OldestListen = oldestListen,
-      Releases = releases,
+      Range = range ?? throw new JsonException("Expected range not found or null."),
+      Releases = releases.VerifyPayloadContents(count),
       TotalCount = totalCount,
       UnhandledProperties = rest,
+      User = user ?? throw new JsonException("Expected user id not found or null."),
     };
   }
 

--- a/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.cs
+++ b/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.cs
@@ -209,6 +209,62 @@ public sealed partial class ListenBrainz {
 
   #region listeners
 
+  /// <summary>Gets information about the top listeners for a particular artist.</summary>
+  /// <param name="mbid">The MusicBrainz ID for the artist.</param>
+  /// <param name="count">
+  /// The (maximum) number of entries to return. If not specified (or <see langword="null"/>), all available information will be
+  /// returned.
+  /// </param>
+  /// <param name="offset">
+  /// The offset (from the start of the results) of the statistics to return for each time range. If not specified (or specified
+  /// as zero or <see langword="null"/>), the top most listened-to artists will be returned. Note that at most 1000 artists will
+  /// be included in the statistics for each time range.
+  /// </param>
+  /// <param name="range">
+  /// The range of data to include in the statistics.<br/>
+  /// If this is unspecified or <see cref="StatisticsRange.AllTime"/>, information is returned about all years with at least one
+  /// recorded listen. Otherwise, information is returned about both the current and the previous range.
+  /// </param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested listener statistics.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IArtistListeners?> GetArtistListenersAsync(Guid mbid, int? count = null, int? offset = null,
+                                                         StatisticsRange? range = null,
+                                                         CancellationToken cancellationToken = default) {
+    var address = $"stats/artist/{mbid}/listeners";
+    var options = ListenBrainz.OptionsForGetStatistics(count, offset, range);
+    return this.GetOptionalAsync<IArtistListeners, ArtistListeners>(address, options, cancellationToken);
+  }
+
+  /// <summary>Gets information about the top listeners for a particular release group.</summary>
+  /// <param name="mbid">The MusicBrainz ID for the release group.</param>
+  /// <param name="count">
+  /// The (maximum) number of entries to return. If not specified (or <see langword="null"/>), all available information will be
+  /// returned.
+  /// </param>
+  /// <param name="offset">
+  /// The offset (from the start of the results) of the statistics to return for each time range. If not specified (or specified
+  /// as zero or <see langword="null"/>), the top most listened-to artists will be returned. Note that at most 1000 artists will
+  /// be included in the statistics for each time range.
+  /// </param>
+  /// <param name="range">
+  /// The range of data to include in the statistics.<br/>
+  /// If this is unspecified or <see cref="StatisticsRange.AllTime"/>, information is returned about all years with at least one
+  /// recorded listen. Otherwise, information is returned about both the current and the previous range.
+  /// </param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested listener statistics.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IReleaseGroupListeners?> GetReleaseGroupListenersAsync(Guid mbid, int? count = null, int? offset = null,
+                                                                     StatisticsRange? range = null,
+                                                                     CancellationToken cancellationToken = default) {
+    var address = $"stats/release-group/{mbid}/listeners";
+    var options = ListenBrainz.OptionsForGetStatistics(count, offset, range);
+    return this.GetOptionalAsync<IReleaseGroupListeners, ReleaseGroupListeners>(address, options, cancellationToken);
+  }
+
   #endregion
 
   #region listening-activity

--- a/MetaBrainz.ListenBrainz/Objects/ArtistListeners.cs
+++ b/MetaBrainz.ListenBrainz/Objects/ArtistListeners.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal sealed class ArtistListeners : ListenerInfo, IArtistListeners {
+
+  public required Guid Id { get; init; }
+
+  public required string Name { get; init; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/FetchedListens.cs
+++ b/MetaBrainz.ListenBrainz/Objects/FetchedListens.cs
@@ -11,19 +11,12 @@ namespace MetaBrainz.ListenBrainz.Objects;
 [UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
 internal sealed class FetchedListens : JsonBasedObject, IFetchedListens {
 
-  public FetchedListens(IReadOnlyList<IListen> listens, long newest, long oldest, string user) {
-    this.Listens = listens;
-    this.Newest = DateTimeOffset.FromUnixTimeSeconds(newest);
-    this.Oldest = DateTimeOffset.FromUnixTimeSeconds(oldest);
-    this.User = user;
-  }
+  public required IReadOnlyList<IListen> Listens { get; init; }
 
-  public IReadOnlyList<IListen> Listens { get; }
+  public required DateTimeOffset Newest { get; init; }
 
-  public DateTimeOffset Newest { get; }
+  public required DateTimeOffset Oldest { get; init; }
 
-  public DateTimeOffset Oldest { get; }
-
-  public string User { get; }
+  public required string User { get; init; }
 
 }

--- a/MetaBrainz.ListenBrainz/Objects/ListenerInfo.cs
+++ b/MetaBrainz.ListenBrainz/Objects/ListenerInfo.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal abstract class ListenerInfo : Statistics, IListenerInfo {
+
+  public required IReadOnlyList<ITopListener> TopListeners { get; init; }
+
+  public required int TotalListens { get; init; }
+
+  public required int TotalListeners { get; init; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/ReleaseGroupListeners.cs
+++ b/MetaBrainz.ListenBrainz/Objects/ReleaseGroupListeners.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal sealed class ReleaseGroupListeners : ListenerInfo, IReleaseGroupListeners {
+
+  public IReadOnlyList<Guid>? ArtistIds { get; init; }
+
+  public string? ArtistName { get; init; }
+
+  public long? CoverArtId { get; init; }
+
+  public Guid? CoverArtReleaseGroupId { get; init; }
+
+  public required Guid Id { get; init; }
+
+  public required string Name { get; init; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/SiteArtistMap.cs
+++ b/MetaBrainz.ListenBrainz/Objects/SiteArtistMap.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 using MetaBrainz.ListenBrainz.Interfaces;
 
 namespace MetaBrainz.ListenBrainz.Objects;
 
-internal sealed class SiteArtistMap(DateTimeOffset lastUpdated, StatisticsRange range)
-  : Statistics(lastUpdated, range), ISiteArtistMap {
+internal sealed class SiteArtistMap : Statistics, ISiteArtistMap {
 
   public IReadOnlyList<IArtistCountryInfo>? Countries { get; init; }
 

--- a/MetaBrainz.ListenBrainz/Objects/SiteArtistStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Objects/SiteArtistStatistics.cs
@@ -1,19 +1,17 @@
-using System;
 using System.Collections.Generic;
 
 using MetaBrainz.ListenBrainz.Interfaces;
 
 namespace MetaBrainz.ListenBrainz.Objects;
 
-internal sealed class SiteArtistStatistics(int count, int totalCount, DateTimeOffset lastUpdated, int offset, StatisticsRange range)
-  : Statistics(lastUpdated, range), ISiteArtistStatistics {
+internal sealed class SiteArtistStatistics : Statistics, ISiteArtistStatistics {
 
   public IReadOnlyList<IArtistInfo>? Artists { get; init; }
 
-  public int Count { get; } = count;
+  public required int Count { get; init; }
 
-  public int Offset { get; } = offset;
+  public required int Offset { get; init; }
 
-  public int TotalCount { get; } = totalCount;
+  public required int TotalCount { get; init; }
 
 }

--- a/MetaBrainz.ListenBrainz/Objects/SiteListeningActivity.cs
+++ b/MetaBrainz.ListenBrainz/Objects/SiteListeningActivity.cs
@@ -1,12 +1,10 @@
-using System;
 using System.Collections.Generic;
 
 using MetaBrainz.ListenBrainz.Interfaces;
 
 namespace MetaBrainz.ListenBrainz.Objects;
 
-internal sealed class SiteListeningActivity(DateTimeOffset lastUpdated, StatisticsRange range)
-  : Statistics(lastUpdated, range), ISiteListeningActivity {
+internal sealed class SiteListeningActivity : Statistics, ISiteListeningActivity {
 
   public IReadOnlyList<IListenTimeRange>? Activity { get; init; }
 

--- a/MetaBrainz.ListenBrainz/Objects/SiteRecordingStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Objects/SiteRecordingStatistics.cs
@@ -1,12 +1,10 @@
-using System;
 using System.Collections.Generic;
 
 using MetaBrainz.ListenBrainz.Interfaces;
 
 namespace MetaBrainz.ListenBrainz.Objects;
 
-internal sealed class SiteRecordingStatistics(DateTimeOffset lastUpdated, StatisticsRange range)
-  : Statistics(lastUpdated, range), ISiteRecordingStatistics {
+internal sealed class SiteRecordingStatistics : Statistics, ISiteRecordingStatistics {
 
   public IReadOnlyList<IRecordingInfo>? Recordings { get; init; }
 

--- a/MetaBrainz.ListenBrainz/Objects/SiteReleaseGroupStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Objects/SiteReleaseGroupStatistics.cs
@@ -1,12 +1,10 @@
-using System;
 using System.Collections.Generic;
 
 using MetaBrainz.ListenBrainz.Interfaces;
 
 namespace MetaBrainz.ListenBrainz.Objects;
 
-internal sealed class SiteReleaseGroupStatistics(DateTimeOffset lastUpdated, StatisticsRange range)
-  : Statistics(lastUpdated, range), ISiteReleaseGroupStatistics {
+internal sealed class SiteReleaseGroupStatistics : Statistics, ISiteReleaseGroupStatistics {
 
   public IReadOnlyList<IReleaseGroupInfo>? ReleaseGroups { get; init; }
 

--- a/MetaBrainz.ListenBrainz/Objects/SiteReleaseStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Objects/SiteReleaseStatistics.cs
@@ -1,12 +1,10 @@
-using System;
 using System.Collections.Generic;
 
 using MetaBrainz.ListenBrainz.Interfaces;
 
 namespace MetaBrainz.ListenBrainz.Objects;
 
-internal sealed class SiteReleaseStatistics(DateTimeOffset lastUpdated, StatisticsRange range)
-  : Statistics(lastUpdated, range), ISiteReleaseStatistics {
+internal sealed class SiteReleaseStatistics : Statistics, ISiteReleaseStatistics {
 
   public IReadOnlyList<IReleaseInfo>? Releases { get; init; }
 

--- a/MetaBrainz.ListenBrainz/Objects/Statistics.cs
+++ b/MetaBrainz.ListenBrainz/Objects/Statistics.cs
@@ -7,17 +7,12 @@ namespace MetaBrainz.ListenBrainz.Objects;
 
 internal abstract class Statistics : JsonBasedObject, IStatistics {
 
-  protected Statistics(DateTimeOffset lastUpdated, StatisticsRange range) {
-    this.LastUpdated = lastUpdated;
-    this.Range = range;
-  }
-
-  public DateTimeOffset LastUpdated { get; }
+  public required DateTimeOffset LastUpdated { get; init; }
 
   public DateTimeOffset? NewestListen { get; init; }
 
   public DateTimeOffset? OldestListen { get; init; }
 
-  public StatisticsRange Range { get; }
+  public required StatisticsRange Range { get; init; }
 
 }

--- a/MetaBrainz.ListenBrainz/Objects/TopListener.cs
+++ b/MetaBrainz.ListenBrainz/Objects/TopListener.cs
@@ -1,0 +1,12 @@
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal sealed class TopListener : JsonBasedObject, ITopListener {
+
+  public required int ListenCount { get; init; }
+
+  public required string UserName { get; init; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/UserArtistMap.cs
+++ b/MetaBrainz.ListenBrainz/Objects/UserArtistMap.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 using MetaBrainz.ListenBrainz.Interfaces;
@@ -6,10 +5,6 @@ using MetaBrainz.ListenBrainz.Interfaces;
 namespace MetaBrainz.ListenBrainz.Objects;
 
 internal sealed class UserArtistMap : UserStatistics, IUserArtistMap {
-
-  public UserArtistMap(DateTimeOffset lastUpdated, StatisticsRange range, string user)
-  : base(lastUpdated, range, user)
-  { }
 
   public IReadOnlyList<IArtistCountryInfo>? Countries { get; init; }
 

--- a/MetaBrainz.ListenBrainz/Objects/UserArtistStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Objects/UserArtistStatistics.cs
@@ -1,20 +1,17 @@
-using System;
 using System.Collections.Generic;
 
 using MetaBrainz.ListenBrainz.Interfaces;
 
 namespace MetaBrainz.ListenBrainz.Objects;
 
-internal sealed class UserArtistStatistics(int count, int totalCount, DateTimeOffset lastUpdated, int offset, StatisticsRange range,
-                                           string user)
-  : UserStatistics(lastUpdated, range, user), IUserArtistStatistics {
+internal sealed class UserArtistStatistics : UserStatistics, IUserArtistStatistics {
 
   public IReadOnlyList<IArtistInfo>? Artists { get; init; }
 
-  public int Count { get; } = count;
+  public required int Count { get; init; }
 
-  public int Offset { get; } = offset;
+  public required int Offset { get; init; }
 
-  public int TotalCount { get; } = totalCount;
+  public required int TotalCount { get; init; }
 
 }

--- a/MetaBrainz.ListenBrainz/Objects/UserDailyActivity.cs
+++ b/MetaBrainz.ListenBrainz/Objects/UserDailyActivity.cs
@@ -1,14 +1,8 @@
-using System;
-
 using MetaBrainz.ListenBrainz.Interfaces;
 
 namespace MetaBrainz.ListenBrainz.Objects;
 
 internal sealed class UserDailyActivity : UserStatistics, IUserDailyActivity {
-
-  public UserDailyActivity(DateTimeOffset lastUpdated, StatisticsRange range, string user)
-  : base(lastUpdated, range, user)
-  { }
 
   public IDailyActivity? Activity { get; init; }
 

--- a/MetaBrainz.ListenBrainz/Objects/UserListeningActivity.cs
+++ b/MetaBrainz.ListenBrainz/Objects/UserListeningActivity.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 using MetaBrainz.ListenBrainz.Interfaces;
@@ -6,10 +5,6 @@ using MetaBrainz.ListenBrainz.Interfaces;
 namespace MetaBrainz.ListenBrainz.Objects;
 
 internal sealed class UserListeningActivity : UserStatistics, IUserListeningActivity {
-
-  public UserListeningActivity(DateTimeOffset lastUpdated, StatisticsRange range, string user)
-  : base(lastUpdated, range, user)
-  { }
 
   public IReadOnlyList<IListenTimeRange>? Activity { get; init; }
 

--- a/MetaBrainz.ListenBrainz/Objects/UserRecordingStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Objects/UserRecordingStatistics.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 using MetaBrainz.ListenBrainz.Interfaces;
@@ -6,10 +5,6 @@ using MetaBrainz.ListenBrainz.Interfaces;
 namespace MetaBrainz.ListenBrainz.Objects;
 
 internal sealed class UserRecordingStatistics : UserStatistics, IUserRecordingStatistics {
-
-  public UserRecordingStatistics(DateTimeOffset lastUpdated, StatisticsRange range, string user)
-  : base(lastUpdated, range, user)
-  { }
 
   public IReadOnlyList<IRecordingInfo>? Recordings { get; init; }
 

--- a/MetaBrainz.ListenBrainz/Objects/UserReleaseGroupStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Objects/UserReleaseGroupStatistics.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 using MetaBrainz.ListenBrainz.Interfaces;
@@ -6,10 +5,6 @@ using MetaBrainz.ListenBrainz.Interfaces;
 namespace MetaBrainz.ListenBrainz.Objects;
 
 internal sealed class UserReleaseGroupStatistics : UserStatistics, IUserReleaseGroupStatistics {
-
-  public UserReleaseGroupStatistics(DateTimeOffset lastUpdated, StatisticsRange range, string user)
-  : base(lastUpdated, range, user)
-  { }
 
   public IReadOnlyList<IReleaseGroupInfo>? ReleaseGroups { get; init; }
 

--- a/MetaBrainz.ListenBrainz/Objects/UserReleaseStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Objects/UserReleaseStatistics.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 using MetaBrainz.ListenBrainz.Interfaces;
@@ -6,10 +5,6 @@ using MetaBrainz.ListenBrainz.Interfaces;
 namespace MetaBrainz.ListenBrainz.Objects;
 
 internal sealed class UserReleaseStatistics : UserStatistics, IUserReleaseStatistics {
-
-  public UserReleaseStatistics(DateTimeOffset lastUpdated, StatisticsRange range, string user)
-  : base(lastUpdated, range, user)
-  { }
 
   public IReadOnlyList<IReleaseInfo>? Releases { get; init; }
 

--- a/MetaBrainz.ListenBrainz/Objects/UserStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Objects/UserStatistics.cs
@@ -6,10 +6,6 @@ namespace MetaBrainz.ListenBrainz.Objects;
 
 internal abstract class UserStatistics : Statistics, IUserStatistics {
 
-  protected UserStatistics(DateTimeOffset lastUpdated, StatisticsRange range, string user) : base(lastUpdated, range) {
-    this.User = user;
-  }
-
-  public string User { get; }
+  public required string User { get; init; }
 
 }

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -118,6 +118,8 @@ public sealed class ListenBrainz : System.IDisposable {
 
   protected override void Finalize();
 
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IArtistListeners?> GetArtistListenersAsync(System.Guid mbid, int? count = default, int? offset = default, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
+
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.ISiteArtistMap?> GetArtistMapAsync(StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
 
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IUserArtistMap?> GetArtistMapAsync(string user, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
@@ -155,6 +157,8 @@ public sealed class ListenBrainz : System.IDisposable {
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.ISiteRecordingStatistics?> GetRecordingStatisticsAsync(int? count = default, int? offset = default, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
 
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IUserRecordingStatistics?> GetRecordingStatisticsAsync(string user, int? count = default, int? offset = default, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IReleaseGroupListeners?> GetReleaseGroupListenersAsync(System.Guid mbid, int? count = default, int? offset = default, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
 
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.ISiteReleaseGroupStatistics?> GetReleaseGroupStatisticsAsync(int? count = default, int? offset = default, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
 
@@ -417,6 +421,22 @@ public interface IArtistInfo : MetaBrainz.Common.Json.IJsonBasedObject {
 }
 ```
 
+### Type: IArtistListeners
+
+```cs
+public interface IArtistListeners : IListenerInfo, IStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.Guid Id {
+    public abstract get;
+  }
+
+  string Name {
+    public abstract get;
+  }
+
+}
+```
+
 ### Type: IArtistMap
 
 ```cs
@@ -583,6 +603,26 @@ public interface IListen : MetaBrainz.Common.Json.IJsonBasedObject {
 public interface IListenCount : MetaBrainz.Common.Json.IJsonBasedObject {
 
   long Count {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IListenerInfo
+
+```cs
+public interface IListenerInfo {
+
+  System.Collections.Generic.IReadOnlyList<ITopListener> TopListeners {
+    public abstract get;
+  }
+
+  int TotalListeners {
+    public abstract get;
+  }
+
+  int TotalListens {
     public abstract get;
   }
 
@@ -799,6 +839,38 @@ public interface IReleaseGroupInfo {
   }
 
   int ListenCount {
+    public abstract get;
+  }
+
+  string Name {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IReleaseGroupListeners
+
+```cs
+public interface IReleaseGroupListeners : IListenerInfo, IStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.Collections.Generic.IReadOnlyList<System.Guid>? ArtistIds {
+    public abstract get;
+  }
+
+  string? ArtistName {
+    public abstract get;
+  }
+
+  long? CoverArtId {
+    public abstract get;
+  }
+
+  System.Guid? CoverArtReleaseGroupId {
+    public abstract get;
+  }
+
+  System.Guid Id {
     public abstract get;
   }
 
@@ -1035,6 +1107,22 @@ public interface ITokenValidationResult {
   }
 
   bool? Valid {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: ITopListener
+
+```cs
+public interface ITopListener : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  int ListenCount {
+    public abstract get;
+  }
+
+  string UserName {
     public abstract get;
   }
 


### PR DESCRIPTION
This adds support for the `/1/artist/<mbid>/listeners` and `/1/release-group/<mbid>/listeners` endpoints.