### PR TITLE
Add artist evolution activity statistics support

### DIFF
--- a/MetaBrainz.ListenBrainz/Interfaces/IArtistEvolutionActivity.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IArtistEvolutionActivity.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>Listening information for artists over time.</summary>
+public interface IArtistEvolutionActivity : IStatistics {
+
+  /// <summary>Artist listening information over a given period of time.</summary>
+  IReadOnlyList<IArtistTimeRange>? Activity { get; }
+
+  /// <summary>The user for whom the information was computed, or <see langword="null"/> if the information is site-wide.</summary>
+  string? User { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/IArtistTimeRange.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IArtistTimeRange.cs
@@ -1,0 +1,45 @@
+﻿using System;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>Artist listening information over a given period of time.</summary>
+public interface IArtistTimeRange {
+
+  /// <summary>The MusicBrainz ID for the artist, if available.</summary>
+  Guid? Id { get; }
+
+  /// <summary>The number of times the artist's tracks were listened to.</summary>
+  int ListenCount { get; }
+
+  /// <summary>The artist's name.</summary>
+  string Name { get; }
+
+  /// <summary>The time unit describing the period for the listen count.</summary>
+  /// <remarks>
+  /// This depends on the requested range for the statistics.
+  /// <list type="table">
+  ///   <listheader>
+  ///     <term>Statistics Range</term>
+  ///     <description>Time Unit</description>
+  ///   </listheader>
+  ///   <item>
+  ///     <term><see cref="StatisticsRange.AllTime"/></term>
+  ///     <description>The (Gregorian) calendar year (e.g. "2019" or "2025").</description>
+  ///   </item>
+  ///   <item>
+  ///     <term><see cref="StatisticsRange.Year"/></term>
+  ///     <description>The (Gregorian, English) month name (e.g. "January" or "August").</description>
+  ///   </item>
+  ///   <item>
+  ///     <term><see cref="StatisticsRange.Month"/></term>
+  ///     <description>The day of the month (e.g. "7" or "13").</description>
+  ///   </item>
+  ///   <item>
+  ///     <term><see cref="StatisticsRange.Week"/></term>
+  ///     <description>The (English) weekday name (e.g. "Sunday" or "Wednesday").</description>
+  ///   </item>
+  /// </list>
+  /// </remarks>
+  string TimeUnit { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Converters.cs
+++ b/MetaBrainz.ListenBrainz/Json/Converters.cs
@@ -11,6 +11,7 @@ internal static class Converters {
   public static IEnumerable<JsonConverter> Readers {
     get {
       yield return ArtistActivityReader.Instance;
+      yield return ArtistEvolutionActivityReader.Instance;
       yield return ArtistListenersReader.Instance;
       yield return ErrorInfoReader.Instance;
       yield return FetchedListensReader.Instance;

--- a/MetaBrainz.ListenBrainz/Json/Readers/AristEvolutionActivityReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/AristEvolutionActivityReader.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+using MetaBrainz.ListenBrainz.Objects;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers;
+
+internal sealed class ArtistEvolutionActivityReader : PayloadReader<ArtistEvolutionActivity> {
+
+  public static readonly ArtistEvolutionActivityReader Instance = new();
+
+  protected override ArtistEvolutionActivity ReadPayload(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    IReadOnlyList<IArtistTimeRange>? activity = null;
+    DateTimeOffset? lastUpdated = null;
+    DateTimeOffset? newestListen = null;
+    DateTimeOffset? oldestListen = null;
+    StatisticsRange? range = null;
+    string? user = null;
+    Dictionary<string, object?>? rest = null;
+    while (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      try {
+        reader.Read();
+        switch (prop) {
+          case "from_ts": {
+            var unixTime = reader.GetOptionalInt64();
+            oldestListen = unixTime is null ? null : DateTimeOffset.FromUnixTimeSeconds(unixTime.Value);
+            break;
+          }
+          case "last_updated":
+            lastUpdated = DateTimeOffset.FromUnixTimeSeconds(reader.GetInt64());
+            break;
+          case "artist_evolution_activity":
+            activity = reader.ReadList(ArtistTimeRangeReader.Instance, options);
+            break;
+          case "range":
+            range = EnumHelper.ParseStatisticsRange(reader.GetString());
+            if (range == StatisticsRange.Unknown) {
+              goto default; // also register it as an unhandled property
+            }
+            break;
+          case "to_ts": {
+            var unixTime = reader.GetOptionalInt64();
+            newestListen = unixTime is null ? null : DateTimeOffset.FromUnixTimeSeconds(unixTime.Value);
+            break;
+          }
+          case "user_id":
+            user = reader.GetString();
+            break;
+          default:
+            rest ??= new Dictionary<string, object?>();
+            rest[prop] = reader.GetOptionalObject(options);
+            break;
+        }
+      }
+      catch (Exception e) {
+        throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+      }
+      reader.Read();
+    }
+    return new ArtistEvolutionActivity {
+      Activity = activity,
+      LastUpdated = lastUpdated ?? throw new JsonException("Expected last-updated timestamp not found or null."),
+      NewestListen = newestListen,
+      OldestListen = oldestListen,
+      Range = range ?? throw new JsonException("Expected range not found or null."),
+      UnhandledProperties = rest,
+      User = user,
+    };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Readers/ArtistTimeRangeReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ArtistTimeRangeReader.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.Common.Json.Converters;
+using MetaBrainz.ListenBrainz.Objects;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers;
+
+internal class ArtistTimeRangeReader : ObjectReader<ArtistTimeRange> {
+
+  public static readonly ArtistTimeRangeReader Instance = new();
+
+  protected override ArtistTimeRange ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    int? listenCount = null;
+    Guid? mbid = null;
+    string? name = null;
+    string? timeUnit = null;
+    Dictionary<string, object?>? rest = null;
+    while (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      try {
+        reader.Read();
+        switch (prop) {
+          case "artist_mbid":
+            mbid = reader.GetOptionalGuid();
+            break;
+          case "artist_name":
+            name = reader.GetString();
+            break;
+          case "listen_count":
+            listenCount = reader.GetInt32();
+            break;
+          case "time_unit":
+            timeUnit = reader.GetString();
+            break;
+          default:
+            rest ??= new Dictionary<string, object?>();
+            rest[prop] = reader.GetOptionalObject(options);
+            break;
+        }
+      }
+      catch (Exception e) {
+        throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+      }
+      reader.Read();
+    }
+    return new ArtistTimeRange {
+      Id = mbid,
+      ListenCount = listenCount ?? throw new JsonException("Expected listen count not found or null."),
+      Name = name ?? throw new JsonException("Expected artist name not found or null."),
+      TimeUnit = timeUnit ?? throw new JsonException("Expected time unit not found or null."),
+      UnhandledProperties = rest,
+    };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.cs
+++ b/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.cs
@@ -92,7 +92,7 @@ public sealed partial class ListenBrainz {
   /// <summary>Gets listening statistics for the top artists (and their albums) across all of ListenBrainz.</summary>
   /// <param name="range">The range of data to include in the statistics.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested information, or <see langword="null"/> if it has not yet been computed for the user.</returns>
+  /// <returns>The requested information, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IArtistActivity?> GetArtistActivityAsync(StatisticsRange? range = null,
@@ -106,7 +106,7 @@ public sealed partial class ListenBrainz {
   /// <param name="user">The user for whom the information is requested.</param>
   /// <param name="range">The range of data to include in the statistics.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested information, or <see langword="null"/> if it has not yet been computed for the user.</returns>
+  /// <returns>The requested information, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IArtistActivity?> GetArtistActivityAsync(string user, StatisticsRange? range = null,
@@ -120,6 +120,37 @@ public sealed partial class ListenBrainz {
 
   #region artist-evolution-activity
 
+  /// <summary>Gets listening statistics for artists over time across all of ListenBrainz.</summary>
+  /// <param name="range">
+  /// The range of data to include in the statistics. This impacts the time units used by the returned information.
+  /// </param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested information, if available.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IArtistEvolutionActivity?> GetArtistEvolutionActivityAsync(StatisticsRange? range = null,
+                                                                         CancellationToken cancellationToken = default) {
+    var address = $"stats/sitewide/artist-evolution-activity";
+    var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
+    return this.GetOptionalAsync<IArtistEvolutionActivity, ArtistEvolutionActivity>(address, options, cancellationToken);
+  }
+
+  /// <summary>Gets a user's listening statistics for artists over time.</summary>
+  /// <param name="user">The user for whom the information is requested.</param>
+  /// <param name="range">
+  /// The range of data to include in the statistics. This impacts the time units used by the returned information.
+  /// </param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested information, if available.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IArtistEvolutionActivity?> GetArtistEvolutionActivityAsync(string user, StatisticsRange? range = null,
+                                                                         CancellationToken cancellationToken = default) {
+    var address = $"stats/user/{user}/artist-evolution-activity";
+    var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
+    return this.GetOptionalAsync<IArtistEvolutionActivity, ArtistEvolutionActivity>(address, options, cancellationToken);
+  }
+
   #endregion
 
   #region artist-map
@@ -129,7 +160,7 @@ public sealed partial class ListenBrainz {
   /// </summary>
   /// <param name="range">The range of data to include in the statistics.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested information, or <see langword="null"/> if it has not yet been computed for the user.</returns>
+  /// <returns>The requested information, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<ISiteArtistMap?> GetArtistMapAsync(StatisticsRange? range = null, CancellationToken cancellationToken = default) {
@@ -141,7 +172,7 @@ public sealed partial class ListenBrainz {
   /// <param name="user">The user for whom the information is requested.</param>
   /// <param name="range">The range of data to include in the statistics.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested information, or <see langword="null"/> if it has not yet been computed for the user.</returns>
+  /// <returns>The requested information, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IUserArtistMap?> GetArtistMapAsync(string user, StatisticsRange? range = null,
@@ -170,7 +201,7 @@ public sealed partial class ListenBrainz {
   /// recorded listen. Otherwise, information is returned about both the current and the previous range.
   /// </param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested artist statistics.</returns>
+  /// <returns>The requested artist statistics, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<ISiteArtistStatistics?> GetArtistStatisticsAsync(int? count = null, int? offset = null,
@@ -193,9 +224,7 @@ public sealed partial class ListenBrainz {
   /// </param>
   /// <param name="range">The range of data to include in the statistics.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>
-  /// The requested artist statistics, or <see langword="null"/> if statistics have not yet been computed for the user.
-  /// </returns>
+  /// <returns>The requested artist statistics, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IUserArtistStatistics?> GetArtistStatisticsAsync(string user, int? count = null, int? offset = null,
@@ -214,7 +243,7 @@ public sealed partial class ListenBrainz {
   /// <param name="user">The user for whom the information is requested.</param>
   /// <param name="range">The range of data to include in the information.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested daily activity.</returns>
+  /// <returns>The requested daily activity, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IUserDailyActivity?> GetDailyActivityAsync(string user, StatisticsRange? range = null,
@@ -253,7 +282,7 @@ public sealed partial class ListenBrainz {
   /// recorded listen. Otherwise, information is returned about both the current and the previous range.
   /// </param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested listener statistics.</returns>
+  /// <returns>The requested listener statistics, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IArtistListeners?> GetArtistListenersAsync(Guid mbid, int? count = null, int? offset = null,
@@ -281,7 +310,7 @@ public sealed partial class ListenBrainz {
   /// recorded listen. Otherwise, information is returned about both the current and the previous range.
   /// </param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested listener statistics.</returns>
+  /// <returns>The requested listener statistics, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IReleaseGroupListeners?> GetReleaseGroupListenersAsync(Guid mbid, int? count = null, int? offset = null,
@@ -303,7 +332,7 @@ public sealed partial class ListenBrainz {
   /// recorded listen. Otherwise, information is returned about both the current and the previous range.
   /// </param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested listening activity.</returns>
+  /// <returns>The requested listening activity, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<ISiteListeningActivity?> GetListeningActivityAsync(StatisticsRange? range = null,
@@ -321,7 +350,7 @@ public sealed partial class ListenBrainz {
   /// recorded listen. Otherwise, information is returned about both the current and the previous range.
   /// </param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested listening activity.</returns>
+  /// <returns>The requested listening activity, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IUserListeningActivity?> GetListeningActivityAsync(string user, StatisticsRange? range = null,
@@ -346,9 +375,7 @@ public sealed partial class ListenBrainz {
   /// </param>
   /// <param name="range">The range of data to include in the statistics.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>
-  /// The requested recording statistics, or <see langword="null"/> if statistics have not yet been computed for the user.
-  /// </returns>
+  /// <returns>The requested recording statistics, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<ISiteRecordingStatistics?> GetRecordingStatisticsAsync(int? count = null, int? offset = null,
@@ -371,9 +398,7 @@ public sealed partial class ListenBrainz {
   /// </param>
   /// <param name="range">The range of data to include in the statistics.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>
-  /// The requested recording statistics, or <see langword="null"/> if statistics have not yet been computed for the user.
-  /// </returns>
+  /// <returns>The requested recording statistics, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IUserRecordingStatistics?> GetRecordingStatisticsAsync(string user, int? count = null, int? offset = null,
@@ -401,9 +426,7 @@ public sealed partial class ListenBrainz {
   /// </param>
   /// <param name="range">The range of data to include in the statistics.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>
-  /// The requested releases statistics, or <see langword="null"/> if statistics have not yet been computed for the user.
-  /// </returns>
+  /// <returns>The requested releases statistics, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<ISiteReleaseGroupStatistics?> GetReleaseGroupStatisticsAsync(int? count = null, int? offset = null,
@@ -426,9 +449,7 @@ public sealed partial class ListenBrainz {
   /// </param>
   /// <param name="range">The range of data to include in the statistics.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>
-  /// The requested releases statistics, or <see langword="null"/> if statistics have not yet been computed for the user.
-  /// </returns>
+  /// <returns>The requested releases statistics, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IUserReleaseGroupStatistics?> GetReleaseGroupStatisticsAsync(string user, int? count = null, int? offset = null,
@@ -454,9 +475,7 @@ public sealed partial class ListenBrainz {
   /// </param>
   /// <param name="range">The range of data to include in the statistics.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>
-  /// The requested releases statistics, or <see langword="null"/> if statistics have not yet been computed for the user.
-  /// </returns>
+  /// <returns>The requested releases statistics, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<ISiteReleaseStatistics?> GetReleaseStatisticsAsync(int? count = null, int? offset = null,
@@ -479,9 +498,7 @@ public sealed partial class ListenBrainz {
   /// </param>
   /// <param name="range">The range of data to include in the statistics.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>
-  /// The requested releases statistics, or <see langword="null"/> if statistics have not yet been computed for the user.
-  /// </returns>
+  /// <returns>The requested releases statistics, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IUserReleaseStatistics?> GetReleaseStatisticsAsync(string user, int? count = null, int? offset = null,

--- a/MetaBrainz.ListenBrainz/Objects/ArtistEvolutionActivity.cs
+++ b/MetaBrainz.ListenBrainz/Objects/ArtistEvolutionActivity.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal sealed class ArtistEvolutionActivity : Statistics, IArtistEvolutionActivity {
+
+  public IReadOnlyList<IArtistTimeRange>? Activity { get; init; }
+
+  public string? User { get; init; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/ArtistTimeRange.cs
+++ b/MetaBrainz.ListenBrainz/Objects/ArtistTimeRange.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal sealed class ArtistTimeRange : JsonBasedObject, IArtistTimeRange {
+
+  public Guid? Id { get; init; }
+
+  public required int ListenCount { get; init; }
+
+  public required string Name { get; init; }
+
+  public required string TimeUnit { get; init; }
+
+}

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -122,6 +122,10 @@ public sealed class ListenBrainz : System.IDisposable {
 
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IArtistActivity?> GetArtistActivityAsync(string user, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
 
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IArtistEvolutionActivity?> GetArtistEvolutionActivityAsync(StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IArtistEvolutionActivity?> GetArtistEvolutionActivityAsync(string user, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
+
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IArtistListeners?> GetArtistListenersAsync(System.Guid mbid, int? count = default, int? offset = default, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
 
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.ISiteArtistMap?> GetArtistMapAsync(StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
@@ -453,6 +457,22 @@ public interface IArtistCredit {
 }
 ```
 
+### Type: IArtistEvolutionActivity
+
+```cs
+public interface IArtistEvolutionActivity : IStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.Collections.Generic.IReadOnlyList<IArtistTimeRange>? Activity {
+    public abstract get;
+  }
+
+  string? User {
+    public abstract get;
+  }
+
+}
+```
+
 ### Type: IArtistInfo
 
 ```cs
@@ -527,6 +547,30 @@ public interface IArtistStatistics {
   }
 
   int TotalCount {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IArtistTimeRange
+
+```cs
+public interface IArtistTimeRange {
+
+  System.Guid? Id {
+    public abstract get;
+  }
+
+  int ListenCount {
+    public abstract get;
+  }
+
+  string Name {
+    public abstract get;
+  }
+
+  string TimeUnit {
     public abstract get;
   }
 


### PR DESCRIPTION
This adds support for the `/1/stats/sitewide/artist-evolution-activity` and `/1/stats/user/xxx/artist-evolution-activity` endpoints.

This also aligns some of the API doc comments for the statistics endpoints.

This is part of the API additions for #59.
