### PR TITLE
Add era activity statistics support

### DIFF
--- a/MetaBrainz.ListenBrainz/Interfaces/IEraActivity.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IEraActivity.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>Listening information by release year.</summary>
+public interface IEraActivity : IStatistics {
+
+  /// <summary>Listening information grouped by release year.</summary>
+  IReadOnlyList<IYearlyActivity>? Activity { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/IYearlyActivity.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IYearlyActivity.cs
@@ -1,0 +1,17 @@
+using JetBrains.Annotations;
+
+using MetaBrainz.Common.Json;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>The number of listens associated with a particular year.</summary>
+[PublicAPI]
+public interface IYearlyActivity : IJsonBasedObject {
+
+  /// <summary>The number of listens recorded.</summary>
+  int ListenCount { get; }
+
+  /// <summary>The year.</summary>
+  int Year { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Converters.cs
+++ b/MetaBrainz.ListenBrainz/Json/Converters.cs
@@ -15,6 +15,7 @@ internal static class Converters {
       yield return ArtistListenersReader.Instance;
       yield return ArtistMapReader.Instance;
       yield return ArtistStatisticsReader.Instance;
+      yield return EraActivityReader.Instance;
       yield return ErrorInfoReader.Instance;
       yield return FetchedListensReader.Instance;
       yield return LatestImportReader.Instance;

--- a/MetaBrainz.ListenBrainz/Json/Readers/EraActivityReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/EraActivityReader.cs
@@ -8,12 +8,12 @@ using MetaBrainz.ListenBrainz.Objects;
 
 namespace MetaBrainz.ListenBrainz.Json.Readers;
 
-internal sealed class ArtistEvolutionActivityReader : PayloadReader<ArtistEvolutionActivity> {
+internal sealed class EraActivityReader : PayloadReader<EraActivity> {
 
-  public static readonly ArtistEvolutionActivityReader Instance = new();
+  public static readonly EraActivityReader Instance = new();
 
-  protected override ArtistEvolutionActivity ReadPayload(ref Utf8JsonReader reader, JsonSerializerOptions options) {
-    IReadOnlyList<IArtistTimeRange>? activity = null;
+  protected override EraActivity ReadPayload(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    IReadOnlyList<IYearlyActivity>? activity = null;
     DateTimeOffset? lastUpdated = null;
     DateTimeOffset? newestListen = null;
     DateTimeOffset? oldestListen = null;
@@ -25,8 +25,8 @@ internal sealed class ArtistEvolutionActivityReader : PayloadReader<ArtistEvolut
       try {
         reader.Read();
         switch (prop) {
-          case "artist_evolution_activity":
-            activity = reader.ReadList(ArtistTimeRangeReader.Instance, options);
+          case "era_activity":
+            activity = reader.ReadList(YearlyActivityReader.Instance, options);
             break;
           case "from_ts": {
             var unixTime = reader.GetOptionalInt64();
@@ -62,7 +62,7 @@ internal sealed class ArtistEvolutionActivityReader : PayloadReader<ArtistEvolut
       }
       reader.Read();
     }
-    return new ArtistEvolutionActivity {
+    return new EraActivity {
       Activity = activity,
       LastUpdated = lastUpdated ?? throw new JsonException("Expected last-updated timestamp not found or null."),
       NewestListen = newestListen,

--- a/MetaBrainz.ListenBrainz/Json/Readers/YearlyActivityReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/YearlyActivityReader.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.Common.Json.Converters;
+using MetaBrainz.ListenBrainz.Objects;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers;
+
+internal sealed class YearlyActivityReader : ObjectReader<YearlyActivity> {
+
+  public static readonly YearlyActivityReader Instance = new();
+
+  protected override YearlyActivity ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    int? listenCount = null;
+    int? year = null;
+    Dictionary<string, object?>? rest = null;
+    while (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      try {
+        reader.Read();
+        switch (prop) {
+          case "listen_count":
+            listenCount = reader.GetInt32();
+            break;
+          case "year":
+            year = reader.GetInt32();
+            break;
+          default:
+            rest ??= new Dictionary<string, object?>();
+            rest[prop] = reader.GetOptionalObject(options);
+            break;
+        }
+      }
+      catch (Exception e) {
+        throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+      }
+      reader.Read();
+    }
+    return new YearlyActivity {
+      ListenCount = listenCount ?? throw new JsonException("Expected listen count not found or null."),
+      UnhandledProperties = rest,
+      Year = year ?? throw new JsonException("Expected year not found or null."),
+    };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.cs
+++ b/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.cs
@@ -256,6 +256,42 @@ public sealed partial class ListenBrainz {
 
   #region era-activity
 
+  /// <summary>
+  /// Gets information about how many listens have been recorded across all of ListenBrainz, grouped by their release year.
+  /// </summary>
+  /// <param name="range">
+  /// The range of data to include in the information.<br/>
+  /// If this is unspecified or <see cref="StatisticsRange.AllTime"/>, information is returned about all years with at least one
+  /// recorded listen. Otherwise, information is returned about both the current and the previous range.
+  /// </param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested listening activity, if available.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IEraActivity?> GetEraActivityAsync(StatisticsRange? range = null, CancellationToken cancellationToken = default) {
+    const string address = "stats/sitewide/era-activity";
+    var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
+    return this.GetOptionalAsync<IEraActivity, EraActivity>(address, options, cancellationToken);
+  }
+
+  /// <summary>Gets information about how many listens have been recorded for a user, grouped by their release year.</summary>
+  /// <param name="user">The user for whom the information is requested.</param>
+  /// <param name="range">
+  /// The range of data to include in the information.<br/>
+  /// If this is unspecified or <see cref="StatisticsRange.AllTime"/>, information is returned about all years with at least one
+  /// recorded listen. Otherwise, information is returned about both the current and the previous range.
+  /// </param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested listening activity, if available.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IEraActivity?> GetEraActivityAsync(string user, StatisticsRange? range = null,
+                                                 CancellationToken cancellationToken = default) {
+    var address = $"stats/user/{user}/era-activity";
+    var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
+    return this.GetOptionalAsync<IEraActivity, EraActivity>(address, options, cancellationToken);
+  }
+
   #endregion
 
   #region genre-activity
@@ -324,7 +360,7 @@ public sealed partial class ListenBrainz {
 
   #region listening-activity
 
-  /// <summary>Gets information about how many listens have been submitted across to ListenBrainz over a period of time.</summary>
+  /// <summary>Gets information about how many listens have been submitted to ListenBrainz over a period of time.</summary>
   /// <param name="range">
   /// The range of data to include in the information.<br/>
   /// If this is unspecified or <see cref="StatisticsRange.AllTime"/>, information is returned about all years with at least one

--- a/MetaBrainz.ListenBrainz/Objects/EraActivity.cs
+++ b/MetaBrainz.ListenBrainz/Objects/EraActivity.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal sealed class EraActivity : Statistics, IEraActivity {
+
+  public IReadOnlyList<IYearlyActivity>? Activity { get; init; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/YearlyActivity.cs
+++ b/MetaBrainz.ListenBrainz/Objects/YearlyActivity.cs
@@ -1,0 +1,12 @@
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal sealed class YearlyActivity : JsonBasedObject, IYearlyActivity {
+
+  public required int ListenCount { get; init; }
+
+  public required int Year { get; init; }
+
+}

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -148,6 +148,10 @@ public sealed class ListenBrainz : System.IDisposable {
 
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IUserDailyActivity?> GetDailyActivityAsync(string user, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
 
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IEraActivity?> GetEraActivityAsync(StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IEraActivity?> GetEraActivityAsync(string user, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
+
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.ILatestImport> GetLatestImportAsync(string user, System.Threading.CancellationToken cancellationToken = default);
 
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IListenCount> GetListenCountAsync(string user, System.Threading.CancellationToken cancellationToken = default);
@@ -622,6 +626,18 @@ public interface IDailyActivity : MetaBrainz.Common.Json.IJsonBasedObject {
   }
 
   System.Collections.Generic.IReadOnlyList<IHourlyActivity>? Wednesday {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IEraActivity
+
+```cs
+public interface IEraActivity : IStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.Collections.Generic.IReadOnlyList<IYearlyActivity>? Activity {
     public abstract get;
   }
 
@@ -1242,6 +1258,22 @@ public interface ITrackInfo : MetaBrainz.Common.Json.IJsonBasedObject {
 public interface IUserDailyActivity : IStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
 
   IDailyActivity? Activity {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IYearlyActivity
+
+```cs
+public interface IYearlyActivity : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  int ListenCount {
+    public abstract get;
+  }
+
+  int Year {
     public abstract get;
   }
 


### PR DESCRIPTION
This adds support for the `/1/stats/sitewide/era-activity` and `/1/stats/user/xxx/era-activity` endpoints.

This is part of the API additions for #59.
