### PR TITLE
Add genre activity statistics support

### DIFF
--- a/MetaBrainz.ListenBrainz/Interfaces/IGenreActivity.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IGenreActivity.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+using MetaBrainz.Common.Json;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>Listening information by genre and hour of day.</summary>
+public interface IGenreActivity : IJsonBasedObject {
+
+  /// <summary>Listening information grouped by genre and hour of day.</summary>
+  IReadOnlyList<IGenreActivityDetails>? Activity { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/IGenreActivityDetails.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IGenreActivityDetails.cs
@@ -1,0 +1,14 @@
+using JetBrains.Annotations;
+
+using MetaBrainz.Common.Json;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>The number of listens associated with a particular genre at a particular hour of the day.</summary>
+[PublicAPI]
+public interface IGenreActivityDetails : IHourlyActivity {
+
+  /// <summary>The genre.</summary>
+  string Genre { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/IHourlyActivity.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IHourlyActivity.cs
@@ -11,7 +11,7 @@ public interface IHourlyActivity : IJsonBasedObject {
   /// <summary>The hour (0-23).</summary>
   int Hour { get; }
 
-  /// <summary>The number of listens recorded this hour.</summary>
+  /// <summary>The number of listens recorded.</summary>
   int ListenCount { get; }
 
 }

--- a/MetaBrainz.ListenBrainz/Json/Converters.cs
+++ b/MetaBrainz.ListenBrainz/Json/Converters.cs
@@ -18,6 +18,7 @@ internal static class Converters {
       yield return EraActivityReader.Instance;
       yield return ErrorInfoReader.Instance;
       yield return FetchedListensReader.Instance;
+      yield return GenreActivityReader.Instance;
       yield return LatestImportReader.Instance;
       yield return ListenCountReader.Instance;
       yield return ListeningActivityReader.Instance;

--- a/MetaBrainz.ListenBrainz/Json/Readers/GenreActivityDetailsReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/GenreActivityDetailsReader.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.Common.Json.Converters;
+using MetaBrainz.ListenBrainz.Objects;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers;
+
+internal sealed class GenreActivityDetailsReader : ObjectReader<GenreActivityDetails> {
+
+  public static readonly GenreActivityDetailsReader Instance = new();
+
+  protected override GenreActivityDetails ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    string? genre = null;
+    int? hour = null;
+    int? listenCount = null;
+    Dictionary<string, object?>? rest = null;
+    while (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      try {
+        reader.Read();
+        switch (prop) {
+          case "genre":
+            genre = reader.GetString();
+            break;
+          case "hour":
+            hour = reader.GetInt32();
+            break;
+          case "listen_count":
+            listenCount = reader.GetInt32();
+            break;
+          default:
+            rest ??= new Dictionary<string, object?>();
+            rest[prop] = reader.GetOptionalObject(options);
+            break;
+        }
+      }
+      catch (Exception e) {
+        throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+      }
+      reader.Read();
+    }
+    if (hour is null) {
+      throw new JsonException("Expected hour not found or null.");
+    }
+    if (hour is < 0 or > 23) {
+      throw new JsonException($"The specified hour ({hour}) is out of range (should be 0-23).");
+    }
+    return new GenreActivityDetails {
+      Genre = genre ?? throw new JsonException("Expected genre not found or null."),
+      Hour = hour.Value,
+      ListenCount = listenCount ?? throw new JsonException("Expected listen count not found or null."),
+      UnhandledProperties = rest,
+    };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Readers/GenreActivityReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/GenreActivityReader.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.Common.Json.Converters;
+using MetaBrainz.ListenBrainz.Interfaces;
+using MetaBrainz.ListenBrainz.Objects;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers;
+
+internal sealed class GenreActivityReader : ObjectReader<GenreActivity> {
+
+  public static readonly GenreActivityReader Instance = new();
+
+  protected override GenreActivity ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    IReadOnlyList<IGenreActivityDetails>? activity = null;
+    Dictionary<string, object?>? rest = null;
+    while (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      try {
+        reader.Read();
+        switch (prop) {
+          case "result":
+            activity = reader.ReadList(GenreActivityDetailsReader.Instance, options);
+            break;
+          default:
+            rest ??= new Dictionary<string, object?>();
+            rest[prop] = reader.GetOptionalObject(options);
+            break;
+        }
+      }
+      catch (Exception e) {
+        throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+      }
+      reader.Read();
+    }
+    if (activity is null) {
+      throw new JsonException("Expected result set not found or null.");
+    }
+    return new GenreActivity {
+      Activity = activity,
+    };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.cs
+++ b/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.cs
@@ -296,6 +296,22 @@ public sealed partial class ListenBrainz {
 
   #region genre-activity
 
+  /// <summary>
+  /// Gets information about how many listens have been recorded for a user, grouped by the genre and the hour of the day.
+  /// </summary>
+  /// <param name="user">The user for whom the information is requested.</param>
+  /// <param name="range">The range of data to include in the information.</param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested listening activity, if available.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IGenreActivity?> GetGenreActivityAsync(string user, StatisticsRange? range = null,
+                                                 CancellationToken cancellationToken = default) {
+    var address = $"stats/user/{user}/genre-activity";
+    var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
+    return this.GetOptionalAsync<IGenreActivity, GenreActivity>(address, options, cancellationToken);
+  }
+
   #endregion
 
   #region listeners

--- a/MetaBrainz.ListenBrainz/Objects/GenreActivity.cs
+++ b/MetaBrainz.ListenBrainz/Objects/GenreActivity.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal sealed class GenreActivity : JsonBasedObject, IGenreActivity {
+
+  public IReadOnlyList<IGenreActivityDetails>? Activity { get; init; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/GenreActivityDetails.cs
+++ b/MetaBrainz.ListenBrainz/Objects/GenreActivityDetails.cs
@@ -1,0 +1,9 @@
+﻿using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal sealed class GenreActivityDetails : HourlyActivity, IGenreActivityDetails {
+
+  public required string Genre { get; init; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/HourlyActivity.cs
+++ b/MetaBrainz.ListenBrainz/Objects/HourlyActivity.cs
@@ -3,7 +3,7 @@ using MetaBrainz.ListenBrainz.Interfaces;
 
 namespace MetaBrainz.ListenBrainz.Objects;
 
-internal sealed class HourlyActivity : JsonBasedObject, IHourlyActivity {
+internal class HourlyActivity : JsonBasedObject, IHourlyActivity {
 
   public required int Hour { get; init; }
 

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -152,6 +152,8 @@ public sealed class ListenBrainz : System.IDisposable {
 
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IEraActivity?> GetEraActivityAsync(string user, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
 
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IGenreActivity?> GetGenreActivityAsync(string user, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
+
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.ILatestImport> GetLatestImportAsync(string user, System.Threading.CancellationToken cancellationToken = default);
 
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IListenCount> GetListenCountAsync(string user, System.Threading.CancellationToken cancellationToken = default);
@@ -662,6 +664,30 @@ public interface IFetchedListens : MetaBrainz.Common.Json.IJsonBasedObject {
   }
 
   string User {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IGenreActivity
+
+```cs
+public interface IGenreActivity : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.Collections.Generic.IReadOnlyList<IGenreActivityDetails>? Activity {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IGenreActivityDetails
+
+```cs
+public interface IGenreActivityDetails : IHourlyActivity, MetaBrainz.Common.Json.IJsonBasedObject {
+
+  string Genre {
     public abstract get;
   }
 


### PR DESCRIPTION
This adds support for the `/1/stats/user/xxx/genre-activity` endpoint.

This is part of the API additions for #59.