### PR TITLE
Add Year in Music support

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.2" />
     <PackageVersion Include="MetaBrainz.Common" Version="4.0.0" />
-    <PackageVersion Include="MetaBrainz.Common.Json" Version="7.0.0" />
+    <PackageVersion Include="MetaBrainz.Common.Json" Version="7.1.0" />
   </ItemGroup>
 
 </Project>

--- a/MetaBrainz.ListenBrainz.sln.DotSettings
+++ b/MetaBrainz.ListenBrainz.sln.DotSettings
@@ -63,6 +63,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Brainz/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=discnumber/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ISRC/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=jspf/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=listenbrainz/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=mbid/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Mbid/@EntryIndexedValue">True</s:Boolean>

--- a/MetaBrainz.ListenBrainz/Interfaces/IAlbumInfo.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IAlbumInfo.cs
@@ -7,7 +7,7 @@ namespace MetaBrainz.ListenBrainz.Interfaces;
 /// <summary>Listening statistics for an album.</summary>
 public interface IAlbumInfo : IJsonBasedObject {
 
-  /// <summary>The MusicBrainz ID for the album's release group, if available.</summary>
+  /// <summary>The MusicBrainz ID for the album's release grouprest ??= [ ];.</summary>
   Guid? Id { get; }
 
   /// <summary>The number of times the album was listened to.</summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/IAlbumInfo.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IAlbumInfo.cs
@@ -7,7 +7,7 @@ namespace MetaBrainz.ListenBrainz.Interfaces;
 /// <summary>Listening statistics for an album.</summary>
 public interface IAlbumInfo : IJsonBasedObject {
 
-  /// <summary>The MusicBrainz ID for the album's release grouprest ??= [ ];.</summary>
+  /// <summary>The MusicBrainz ID for the album's release group.</summary>
   Guid? Id { get; }
 
   /// <summary>The number of times the album was listened to.</summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/IArtistActivityInfo.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IArtistActivityInfo.cs
@@ -11,7 +11,7 @@ public interface IArtistActivityInfo : IJsonBasedObject {
   /// <summary>Listening statistics for the artist's albums.</summary>
   IReadOnlyList<IAlbumInfo> Albums { get; }
 
-  /// <summary>The MusicBrainz ID for the artistrest ??= [ ];.</summary>
+  /// <summary>The MusicBrainz ID for the artist.</summary>
   Guid? Id { get; }
 
   /// <summary>The number of times the artist was listened to.</summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/IArtistActivityInfo.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IArtistActivityInfo.cs
@@ -11,7 +11,7 @@ public interface IArtistActivityInfo : IJsonBasedObject {
   /// <summary>Listening statistics for the artist's albums.</summary>
   IReadOnlyList<IAlbumInfo> Albums { get; }
 
-  /// <summary>The MusicBrainz ID for the artist, if available.</summary>
+  /// <summary>The MusicBrainz ID for the artistrest ??= [ ];.</summary>
   Guid? Id { get; }
 
   /// <summary>The number of times the artist was listened to.</summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/IArtistInfo.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IArtistInfo.cs
@@ -11,10 +11,10 @@ namespace MetaBrainz.ListenBrainz.Interfaces;
 [PublicAPI]
 public interface IArtistInfo : IJsonBasedObject {
 
-  /// <summary>The MusicBrainz ID for the artistrest ??= [ ];.</summary>
+  /// <summary>The MusicBrainz ID for the artist.</summary>
   Guid? Id { get; }
 
-  /// <summary>The MusicBrainz IDs for the artistrest ??= [ ];.</summary>
+  /// <summary>The MusicBrainz IDs for the artist.</summary>
   /// <remarks>
   /// This may be obsolete; the current API only ever seems to return a single ID, which will be available in <see cref="Id"/>.
   /// </remarks>
@@ -23,7 +23,7 @@ public interface IArtistInfo : IJsonBasedObject {
   /// <summary>The number of times the artist's tracks were listened to.</summary>
   int ListenCount { get; }
 
-  /// <summary>The MessyBrainz ID for the artistrest ??= [ ];.</summary>
+  /// <summary>The MessyBrainz ID for the artist.</summary>
   Guid? MessyId { get; }
 
   /// <summary>The artist's name.</summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/IArtistInfo.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IArtistInfo.cs
@@ -11,10 +11,10 @@ namespace MetaBrainz.ListenBrainz.Interfaces;
 [PublicAPI]
 public interface IArtistInfo : IJsonBasedObject {
 
-  /// <summary>The MusicBrainz ID for the artist, if available.</summary>
+  /// <summary>The MusicBrainz ID for the artistrest ??= [ ];.</summary>
   Guid? Id { get; }
 
-  /// <summary>The MusicBrainz IDs for the artist, if available.</summary>
+  /// <summary>The MusicBrainz IDs for the artistrest ??= [ ];.</summary>
   /// <remarks>
   /// This may be obsolete; the current API only ever seems to return a single ID, which will be available in <see cref="Id"/>.
   /// </remarks>
@@ -23,7 +23,7 @@ public interface IArtistInfo : IJsonBasedObject {
   /// <summary>The number of times the artist's tracks were listened to.</summary>
   int ListenCount { get; }
 
-  /// <summary>The MessyBrainz ID for the artist, if available.</summary>
+  /// <summary>The MessyBrainz ID for the artistrest ??= [ ];.</summary>
   Guid? MessyId { get; }
 
   /// <summary>The artist's name.</summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/IArtistTimeRange.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IArtistTimeRange.cs
@@ -5,7 +5,7 @@ namespace MetaBrainz.ListenBrainz.Interfaces;
 /// <summary>Artist listening information over a given period of time.</summary>
 public interface IArtistTimeRange {
 
-  /// <summary>The MusicBrainz ID for the artist, if available.</summary>
+  /// <summary>The MusicBrainz ID for the artistrest ??= [ ];.</summary>
   Guid? Id { get; }
 
   /// <summary>The number of times the artist's tracks were listened to.</summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/IArtistTimeRange.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IArtistTimeRange.cs
@@ -5,7 +5,7 @@ namespace MetaBrainz.ListenBrainz.Interfaces;
 /// <summary>Artist listening information over a given period of time.</summary>
 public interface IArtistTimeRange {
 
-  /// <summary>The MusicBrainz ID for the artistrest ??= [ ];.</summary>
+  /// <summary>The MusicBrainz ID for the artist.</summary>
   Guid? Id { get; }
 
   /// <summary>The number of times the artist's tracks were listened to.</summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/IMusicBrainzIdMappings.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IMusicBrainzIdMappings.cs
@@ -15,10 +15,10 @@ public interface IMusicBrainzIdMappings {
   /// <summary>The MusicBrainz IDs for the track's artists.</summary>
   IReadOnlyList<Guid>? ArtistIds { get; }
 
-  /// <summary>The internal ID for the track's release in the CoverArt Archive.</summary>
+  /// <summary>The internal ID for the track in the CoverArt Archive.</summary>
   long? CoverArtId { get; }
 
-  /// <summary>The MusicBrainz ID for the track's release in the CoverArt Archive.</summary>
+  /// <summary>The MusicBrainz release ID for the track in the CoverArt Archive.</summary>
   Guid? CoverArtReleaseId { get; }
 
   /// <summary>The MusicBrainz credits for the track's artists.</summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/INewRelease.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/INewRelease.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>Information about a new release from a particular year.</summary>
+public interface INewRelease {
+
+  /// <summary>The internal ID for the release in the CoverArt Archive.</summary>
+  /// <remarks>This field is only provided for the Year in Music 2022 and later.</remarks>
+  long? CoverArtId { get; }
+
+  /// <summary>The MusicBrainz ID for the release in the CoverArt Archive.</summary>
+  /// <remarks>This field is only provided for the Year in Music 2022 and later.</remarks>
+  Guid? CoverArtReleaseId { get; }
+
+  /// <summary>
+  /// The release's credited artist name.<br/>
+  /// This may combine multiple distinct artists; look at <see cref="CreditedArtists"/> for details.
+  /// </summary>
+  /// <remarks>This field is only provided for the Year in Music 2023 and later.</remarks>
+  string? CreditedArtist { get; }
+
+  /// <summary>The MusicBrainz IDs for the release's credited artist(s).</summary>
+  IReadOnlyList<Guid>? CreditedArtistIds { get; }
+
+  /// <summary>The names of the release's credited artists.</summary>
+  /// <remarks>
+  /// This field is only provided for the Year in Music 2021; later versions provide <see cref="CreditedArtist"/> and (from 2023
+  /// onwards) <see cref="CreditedArtists"/> instead.
+  /// </remarks>
+  IReadOnlyList<string>? CreditedArtistNames { get; }
+
+  /// <summary>Information about the release's credited artists.</summary>
+  /// <remarks>This field is only provided for the Year in Music 2023 and later.</remarks>
+  IReadOnlyList<IArtistCredit>? CreditedArtists { get; }
+
+  /// <summary>The date this was first released.</summary>
+  /// <remarks>This field is only provided for the Year in Music 2021.</remarks>
+  string? FirstReleaseDate { get; }
+
+  /// <summary>The MusicBrainz release ID for the release.</summary>
+  /// <remarks>This field is only provided for the Year in Music 2021.</remarks>
+  Guid? ReleaseId { get; }
+
+  /// <summary>The MusicBrainz release group ID for the release.</summary>
+  /// <remarks>This field is only provided for the Year in Music 2022 and later.</remarks>
+  Guid? ReleaseGroupId { get; }
+
+  /// <summary>The release's title.</summary>
+  string Title { get; }
+
+  /// <summary>The type of release's title.</summary>
+  /// <remarks>This field is only provided for the Year in Music 2021.</remarks>
+  string? Type { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/INewRelease.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/INewRelease.cs
@@ -10,7 +10,7 @@ public interface INewRelease {
   /// <remarks>This field is only provided for the Year in Music 2022 and later.</remarks>
   long? CoverArtId { get; }
 
-  /// <summary>The MusicBrainz ID for the release in the CoverArt Archive.</summary>
+  /// <summary>The MusicBrainz release ID for the release in the CoverArt Archive.</summary>
   /// <remarks>This field is only provided for the Year in Music 2022 and later.</remarks>
   Guid? CoverArtReleaseId { get; }
 

--- a/MetaBrainz.ListenBrainz/Interfaces/IRecordingInfo.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IRecordingInfo.cs
@@ -9,13 +9,13 @@ namespace MetaBrainz.ListenBrainz.Interfaces;
 [PublicAPI]
 public interface IRecordingInfo {
 
-  /// <summary>The MusicBrainz IDs for the recording's artist(s), if available.</summary>
+  /// <summary>The MusicBrainz IDs for the recording's artist(s)rest ??= [ ];.</summary>
   IReadOnlyList<Guid>? ArtistIds { get; }
 
-  /// <summary>The MessyBrainz ID for the recording's artist, if available.</summary>
+  /// <summary>The MessyBrainz ID for the recording's artistrest ??= [ ];.</summary>
   Guid? ArtistMessyId { get; }
 
-  /// <summary>The recording's artist's name, if available.</summary>
+  /// <summary>The recording's artist's namerest ??= [ ];.</summary>
   string? ArtistName { get; }
 
   /// <summary>The internal ID for the recording's release in the CoverArt Archive.</summary>
@@ -30,22 +30,22 @@ public interface IRecordingInfo {
   /// <summary>The number of times the recording was listened to.</summary>
   int ListenCount { get; }
 
-  /// <summary>The MusicBrainz ID for the recording, if available.</summary>
+  /// <summary>The MusicBrainz ID for the recordingrest ??= [ ];.</summary>
   Guid? Id { get; }
 
-  /// <summary>The MessyBrainz ID for the recording, if available.</summary>
+  /// <summary>The MessyBrainz ID for the recordingrest ??= [ ];.</summary>
   Guid? MessyId { get; }
 
   /// <summary>The recording's name.</summary>
   string Name { get; }
 
-  /// <summary>The MusicBrainz IDs for the recording's release, if available.</summary>
+  /// <summary>The MusicBrainz IDs for the recording's releaserest ??= [ ];.</summary>
   Guid? ReleaseId { get; }
 
-  /// <summary>The MessyBrainz ID for the recording's release, if available.</summary>
+  /// <summary>The MessyBrainz ID for the recording's releaserest ??= [ ];.</summary>
   Guid? ReleaseMessyId { get; }
 
-  /// <summary>The recording's release's name, if available.</summary>
+  /// <summary>The recording's release's namerest ??= [ ];.</summary>
   string? ReleaseName { get; }
 
 }

--- a/MetaBrainz.ListenBrainz/Interfaces/IRecordingInfo.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IRecordingInfo.cs
@@ -18,10 +18,10 @@ public interface IRecordingInfo {
   /// <summary>The recording's artist's name.</summary>
   string? ArtistName { get; }
 
-  /// <summary>The internal ID for the recording's release in the CoverArt Archive.</summary>
+  /// <summary>The internal ID for the recording in the CoverArt Archive.</summary>
   long? CoverArtId { get; }
 
-  /// <summary>The MusicBrainz ID for the recording's release in the CoverArt Archive.</summary>
+  /// <summary>The MusicBrainz release ID for the recording in the CoverArt Archive.</summary>
   Guid? CoverArtReleaseId { get; }
 
   /// <summary>The MusicBrainz credits for the recording's artists.</summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/IRecordingInfo.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IRecordingInfo.cs
@@ -9,13 +9,13 @@ namespace MetaBrainz.ListenBrainz.Interfaces;
 [PublicAPI]
 public interface IRecordingInfo {
 
-  /// <summary>The MusicBrainz IDs for the recording's artist(s)rest ??= [ ];.</summary>
+  /// <summary>The MusicBrainz IDs for the recording's artist(s).</summary>
   IReadOnlyList<Guid>? ArtistIds { get; }
 
-  /// <summary>The MessyBrainz ID for the recording's artistrest ??= [ ];.</summary>
+  /// <summary>The MessyBrainz ID for the recording's artist.</summary>
   Guid? ArtistMessyId { get; }
 
-  /// <summary>The recording's artist's namerest ??= [ ];.</summary>
+  /// <summary>The recording's artist's name.</summary>
   string? ArtistName { get; }
 
   /// <summary>The internal ID for the recording's release in the CoverArt Archive.</summary>
@@ -30,22 +30,22 @@ public interface IRecordingInfo {
   /// <summary>The number of times the recording was listened to.</summary>
   int ListenCount { get; }
 
-  /// <summary>The MusicBrainz ID for the recordingrest ??= [ ];.</summary>
+  /// <summary>The MusicBrainz ID for the recording.</summary>
   Guid? Id { get; }
 
-  /// <summary>The MessyBrainz ID for the recordingrest ??= [ ];.</summary>
+  /// <summary>The MessyBrainz ID for the recording.</summary>
   Guid? MessyId { get; }
 
   /// <summary>The recording's name.</summary>
   string Name { get; }
 
-  /// <summary>The MusicBrainz IDs for the recording's releaserest ??= [ ];.</summary>
+  /// <summary>The MusicBrainz IDs for the recording's release.</summary>
   Guid? ReleaseId { get; }
 
-  /// <summary>The MessyBrainz ID for the recording's releaserest ??= [ ];.</summary>
+  /// <summary>The MessyBrainz ID for the recording's release.</summary>
   Guid? ReleaseMessyId { get; }
 
-  /// <summary>The recording's release's namerest ??= [ ];.</summary>
+  /// <summary>The recording's release's name.</summary>
   string? ReleaseName { get; }
 
 }

--- a/MetaBrainz.ListenBrainz/Interfaces/IRecordingStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IRecordingStatistics.cs
@@ -14,7 +14,7 @@ public interface IRecordingStatistics : IStatistics {
   /// <summary>The offset of these statistics from the start of the full set.</summary>
   int? Offset { get; }
 
-  /// <summary>The total number of (distinct) recordings listened to, if available.</summary>
+  /// <summary>The total number of (distinct) recordings listened torest ??= [ ];.</summary>
   int? TotalCount { get; }
 
 }

--- a/MetaBrainz.ListenBrainz/Interfaces/IRecordingStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IRecordingStatistics.cs
@@ -14,7 +14,7 @@ public interface IRecordingStatistics : IStatistics {
   /// <summary>The offset of these statistics from the start of the full set.</summary>
   int? Offset { get; }
 
-  /// <summary>The total number of (distinct) recordings listened torest ??= [ ];.</summary>
+  /// <summary>The total number of (distinct) recordings listened to.</summary>
   int? TotalCount { get; }
 
 }

--- a/MetaBrainz.ListenBrainz/Interfaces/IReleaseGroupInfo.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IReleaseGroupInfo.cs
@@ -23,8 +23,8 @@ public interface IReleaseGroupInfo : IJsonBasedObject {
   /// <summary>The internal ID for the release group in the CoverArt Archive.</summary>
   long? CoverArtId { get; }
 
-  /// <summary>The MusicBrainz ID for the release group in the CoverArt Archive.</summary>
-  Guid? CoverArtReleaseGroupId { get; }
+  /// <summary>The MusicBrainz release ID for the release group in the CoverArt Archive.</summary>
+  Guid? CoverArtReleaseId { get; }
 
   /// <summary>The MusicBrainz credits for the release group's artists.</summary>
   IReadOnlyList<IArtistCredit>? Credits { get; }

--- a/MetaBrainz.ListenBrainz/Interfaces/IReleaseGroupInfo.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IReleaseGroupInfo.cs
@@ -3,16 +3,21 @@ using System.Collections.Generic;
 
 using JetBrains.Annotations;
 
+using MetaBrainz.Common.Json;
+
 namespace MetaBrainz.ListenBrainz.Interfaces;
 
 /// <summary>Statistical information about a release group.</summary>
 [PublicAPI]
-public interface IReleaseGroupInfo {
+public interface IReleaseGroupInfo : IJsonBasedObject {
 
-  /// <summary>The MusicBrainz IDs for the release group's artist(s), if available.</summary>
+  /// <summary>The MusicBrainz IDs for the release group's credited artist(s).</summary>
   IReadOnlyList<Guid>? ArtistIds { get; }
 
-  /// <summary>The release group's artist's name, if available.</summary>
+  /// <summary>
+  /// The release group's credited artist name.<br/>
+  /// This may combine multiple distinct artists; look at <see cref="Credits"/> for details.
+  /// </summary>
   string? ArtistName { get; }
 
   /// <summary>The internal ID for the release group in the CoverArt Archive.</summary>
@@ -24,7 +29,7 @@ public interface IReleaseGroupInfo {
   /// <summary>The MusicBrainz credits for the release group's artists.</summary>
   IReadOnlyList<IArtistCredit>? Credits { get; }
 
-  /// <summary>The MusicBrainz ID for the release group, if available.</summary>
+  /// <summary>The MusicBrainz ID for the release group.</summary>
   Guid? Id { get; }
 
   /// <summary>The number of times the release group's tracks were listened to.</summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/IReleaseGroupListeners.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IReleaseGroupListeners.cs
@@ -6,10 +6,10 @@ namespace MetaBrainz.ListenBrainz.Interfaces;
 /// <summary>Information about a release group's top listeners.</summary>
 public interface IReleaseGroupListeners : IListenerInfo, IStatistics {
 
-  /// <summary>The MusicBrainz IDs for the release group's artist(s)rest ??= [ ];.</summary>
+  /// <summary>The MusicBrainz IDs for the release group's artist(s).</summary>
   IReadOnlyList<Guid>? ArtistIds { get; }
 
-  /// <summary>The release group's artist's namerest ??= [ ];.</summary>
+  /// <summary>The release group's artist's name.</summary>
   string? ArtistName { get; }
 
   /// <summary>The internal ID for the release group in the CoverArt Archive.</summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/IReleaseGroupListeners.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IReleaseGroupListeners.cs
@@ -15,8 +15,8 @@ public interface IReleaseGroupListeners : IListenerInfo, IStatistics {
   /// <summary>The internal ID for the release group in the CoverArt Archive.</summary>
   long? CoverArtId { get; }
 
-  /// <summary>The MusicBrainz ID for the release group in the CoverArt Archive.</summary>
-  Guid? CoverArtReleaseGroupId { get; }
+  /// <summary>The MusicBrainz release ID for the release group in the CoverArt Archive.</summary>
+  Guid? CoverArtReleaseId { get; }
 
   /// <summary>The MusicBrainz ID for the release group.</summary>
   Guid Id { get; }

--- a/MetaBrainz.ListenBrainz/Interfaces/IReleaseGroupListeners.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IReleaseGroupListeners.cs
@@ -6,10 +6,10 @@ namespace MetaBrainz.ListenBrainz.Interfaces;
 /// <summary>Information about a release group's top listeners.</summary>
 public interface IReleaseGroupListeners : IListenerInfo, IStatistics {
 
-  /// <summary>The MusicBrainz IDs for the release group's artist(s), if available.</summary>
+  /// <summary>The MusicBrainz IDs for the release group's artist(s)rest ??= [ ];.</summary>
   IReadOnlyList<Guid>? ArtistIds { get; }
 
-  /// <summary>The release group's artist's name, if available.</summary>
+  /// <summary>The release group's artist's namerest ??= [ ];.</summary>
   string? ArtistName { get; }
 
   /// <summary>The internal ID for the release group in the CoverArt Archive.</summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/IReleaseGroupStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IReleaseGroupStatistics.cs
@@ -14,7 +14,7 @@ public interface IReleaseGroupStatistics : IStatistics {
   /// <summary>The offset of these statistics from the start of the full set.</summary>
   int? Offset { get; }
 
-  /// <summary>The total number of (distinct) releases listened torest ??= [ ];.</summary>
+  /// <summary>The total number of (distinct) releases listened to.</summary>
   int? TotalCount { get; }
 
 }

--- a/MetaBrainz.ListenBrainz/Interfaces/IReleaseGroupStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IReleaseGroupStatistics.cs
@@ -14,7 +14,7 @@ public interface IReleaseGroupStatistics : IStatistics {
   /// <summary>The offset of these statistics from the start of the full set.</summary>
   int? Offset { get; }
 
-  /// <summary>The total number of (distinct) releases listened to, if available.</summary>
+  /// <summary>The total number of (distinct) releases listened torest ??= [ ];.</summary>
   int? TotalCount { get; }
 
 }

--- a/MetaBrainz.ListenBrainz/Interfaces/IReleaseInfo.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IReleaseInfo.cs
@@ -9,13 +9,13 @@ namespace MetaBrainz.ListenBrainz.Interfaces;
 [PublicAPI]
 public interface IReleaseInfo {
 
-  /// <summary>The MusicBrainz IDs for the release's artist(s)rest ??= [ ];.</summary>
+  /// <summary>The MusicBrainz IDs for the release's artist(s).</summary>
   IReadOnlyList<Guid>? ArtistIds { get; }
 
-  /// <summary>The MessyBrainz ID for the release's artistrest ??= [ ];.</summary>
+  /// <summary>The MessyBrainz ID for the release's artist.</summary>
   Guid? ArtistMessyId { get; }
 
-  /// <summary>The release's artist's namerest ??= [ ];.</summary>
+  /// <summary>The release's artist's name.</summary>
   string? ArtistName { get; }
 
   /// <summary>The internal ID for the release in the CoverArt Archive.</summary>
@@ -27,13 +27,13 @@ public interface IReleaseInfo {
   /// <summary>The MusicBrainz credits for the release's artists.</summary>
   IReadOnlyList<IArtistCredit>? Credits { get; }
 
-  /// <summary>The MusicBrainz ID for the releaserest ??= [ ];.</summary>
+  /// <summary>The MusicBrainz ID for the release.</summary>
   Guid? Id { get; }
 
   /// <summary>The number of times the release's tracks were listened to.</summary>
   int ListenCount { get; }
 
-  /// <summary>The MessyBrainz ID for the releaserest ??= [ ];.</summary>
+  /// <summary>The MessyBrainz ID for the release.</summary>
   Guid? MessyId { get; }
 
   /// <summary>The release's name.</summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/IReleaseInfo.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IReleaseInfo.cs
@@ -9,13 +9,13 @@ namespace MetaBrainz.ListenBrainz.Interfaces;
 [PublicAPI]
 public interface IReleaseInfo {
 
-  /// <summary>The MusicBrainz IDs for the release's artist(s), if available.</summary>
+  /// <summary>The MusicBrainz IDs for the release's artist(s)rest ??= [ ];.</summary>
   IReadOnlyList<Guid>? ArtistIds { get; }
 
-  /// <summary>The MessyBrainz ID for the release's artist, if available.</summary>
+  /// <summary>The MessyBrainz ID for the release's artistrest ??= [ ];.</summary>
   Guid? ArtistMessyId { get; }
 
-  /// <summary>The release's artist's name, if available.</summary>
+  /// <summary>The release's artist's namerest ??= [ ];.</summary>
   string? ArtistName { get; }
 
   /// <summary>The internal ID for the release in the CoverArt Archive.</summary>
@@ -27,13 +27,13 @@ public interface IReleaseInfo {
   /// <summary>The MusicBrainz credits for the release's artists.</summary>
   IReadOnlyList<IArtistCredit>? Credits { get; }
 
-  /// <summary>The MusicBrainz ID for the release, if available.</summary>
+  /// <summary>The MusicBrainz ID for the releaserest ??= [ ];.</summary>
   Guid? Id { get; }
 
   /// <summary>The number of times the release's tracks were listened to.</summary>
   int ListenCount { get; }
 
-  /// <summary>The MessyBrainz ID for the release, if available.</summary>
+  /// <summary>The MessyBrainz ID for the releaserest ??= [ ];.</summary>
   Guid? MessyId { get; }
 
   /// <summary>The release's name.</summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/IReleaseInfo.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IReleaseInfo.cs
@@ -21,7 +21,7 @@ public interface IReleaseInfo {
   /// <summary>The internal ID for the release in the CoverArt Archive.</summary>
   long? CoverArtId { get; }
 
-  /// <summary>The MusicBrainz ID for the release in the CoverArt Archive.</summary>
+  /// <summary>The MusicBrainz release ID for the release in the CoverArt Archive.</summary>
   Guid? CoverArtReleaseId { get; }
 
   /// <summary>The MusicBrainz credits for the release's artists.</summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/IReleaseStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IReleaseStatistics.cs
@@ -14,7 +14,7 @@ public interface IReleaseStatistics : IStatistics {
   /// <summary>The offset of these statistics from the start of the full set.</summary>
   int? Offset { get; }
 
-  /// <summary>The total number of (distinct) releases listened torest ??= [ ];.</summary>
+  /// <summary>The total number of (distinct) releases listened to.</summary>
   int? TotalCount { get; }
 
 }

--- a/MetaBrainz.ListenBrainz/Interfaces/IReleaseStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IReleaseStatistics.cs
@@ -14,7 +14,7 @@ public interface IReleaseStatistics : IStatistics {
   /// <summary>The offset of these statistics from the start of the full set.</summary>
   int? Offset { get; }
 
-  /// <summary>The total number of (distinct) releases listened to, if available.</summary>
+  /// <summary>The total number of (distinct) releases listened torest ??= [ ];.</summary>
   int? TotalCount { get; }
 
 }

--- a/MetaBrainz.ListenBrainz/Interfaces/ISimilarUser.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ISimilarUser.cs
@@ -1,0 +1,14 @@
+﻿using MetaBrainz.Common.Json;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>Information about similar users.</summary>
+public interface ISimilarUser : IJsonBasedObject {
+
+  /// <summary>The name of the user.</summary>
+  string Name { get; }
+
+  /// <summary>The similarity of the user, expressed as a percentage.</summary>
+  decimal Similarity { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/IStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IStatistics.cs
@@ -13,10 +13,10 @@ public interface IStatistics : IJsonBasedObject {
   /// <summary>The timestamp at which the statistics were last updated.</summary>
   DateTimeOffset LastUpdated { get; }
 
-  /// <summary>The most recent listen timestamp used for these statisticsrest ??= [ ];.</summary>
+  /// <summary>The most recent listen timestamp used for these statistics.</summary>
   DateTimeOffset? NewestListen { get; }
 
-  /// <summary>The oldest listen timestamp used for these statisticsrest ??= [ ];.</summary>
+  /// <summary>The oldest listen timestamp used for these statistics.</summary>
   DateTimeOffset? OldestListen { get; }
 
   /// <summary>The range of data used when computing the statistics.</summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/IStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IStatistics.cs
@@ -13,10 +13,10 @@ public interface IStatistics : IJsonBasedObject {
   /// <summary>The timestamp at which the statistics were last updated.</summary>
   DateTimeOffset LastUpdated { get; }
 
-  /// <summary>The most recent listen timestamp used for these statistics, if available.</summary>
+  /// <summary>The most recent listen timestamp used for these statisticsrest ??= [ ];.</summary>
   DateTimeOffset? NewestListen { get; }
 
-  /// <summary>The oldest listen timestamp used for these statistics, if available.</summary>
+  /// <summary>The oldest listen timestamp used for these statisticsrest ??= [ ];.</summary>
   DateTimeOffset? OldestListen { get; }
 
   /// <summary>The range of data used when computing the statistics.</summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/ITokenValidationResult.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ITokenValidationResult.cs
@@ -14,7 +14,7 @@ public interface ITokenValidationResult {
   /// <summary>The message for the request.</summary>
   public string Message { get; }
 
-  /// <summary>The user name associated with the token, if available.</summary>
+  /// <summary>The user name associated with the tokenrest ??= [ ];.</summary>
   public string? User { get; }
 
   /// <summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/ITokenValidationResult.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ITokenValidationResult.cs
@@ -14,7 +14,7 @@ public interface ITokenValidationResult {
   /// <summary>The message for the request.</summary>
   public string Message { get; }
 
-  /// <summary>The user name associated with the tokenrest ??= [ ];.</summary>
+  /// <summary>The user name associated with the token.</summary>
   public string? User { get; }
 
   /// <summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/ITopArtist.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ITopArtist.cs
@@ -7,7 +7,7 @@ namespace MetaBrainz.ListenBrainz.Interfaces;
 /// <summary>Information about one of a user's most listened to artists.</summary>
 public interface ITopArtist : IJsonBasedObject {
 
-  /// <summary>The MusicBrainz ID for the artistrest ??= [ ];.</summary>
+  /// <summary>The MusicBrainz ID for the artist.</summary>
   Guid? Id { get; }
 
   /// <summary>The number of times the artist was listened to.</summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/ITopArtist.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ITopArtist.cs
@@ -7,7 +7,7 @@ namespace MetaBrainz.ListenBrainz.Interfaces;
 /// <summary>Information about one of a user's most listened to artists.</summary>
 public interface ITopArtist : IJsonBasedObject {
 
-  /// <summary>The MusicBrainz ID for the artist, if available.</summary>
+  /// <summary>The MusicBrainz ID for the artistrest ??= [ ];.</summary>
   Guid? Id { get; }
 
   /// <summary>The number of times the artist was listened to.</summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/ITopArtist.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ITopArtist.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+using MetaBrainz.Common.Json;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>Information about one of a user's most listened to artists.</summary>
+public interface ITopArtist : IJsonBasedObject {
+
+  /// <summary>The MusicBrainz ID for the artist, if available.</summary>
+  Guid? Id { get; }
+
+  /// <summary>The number of times the artist was listened to.</summary>
+  int ListenCount { get; }
+
+  /// <summary>The artist's name.</summary>
+  string Name { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/ITopGenre.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ITopGenre.cs
@@ -1,0 +1,17 @@
+﻿using MetaBrainz.Common.Json;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>Information about one of a user's top genres.</summary>
+public interface ITopGenre : IJsonBasedObject {
+
+  /// <summary>The genre.</summary>
+  string Genre { get; }
+
+  /// <summary>The number of listens for recordings tagged as the genre.</summary>
+  int ListenCount { get; }
+
+  /// <summary>The percentage of listening time accounted for by this genre.</summary>
+  decimal Percentage { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/ITopRecording.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ITopRecording.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+
+using MetaBrainz.Common.Json;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>Information about one of a user's most listened to recordings (tracks).</summary>
+public interface ITopRecording : IJsonBasedObject {
+
+  /// <summary>The MusicBrainz IDs for the recording's credited artist(s).</summary>
+  IReadOnlyList<Guid>? ArtistIds { get; }
+
+  /// <summary>
+  /// The recording's credited artist name.<br/>
+  /// This may combine multiple distinct artists; look at <see cref="Credits"/> for details.
+  /// </summary>
+  string? ArtistName { get; }
+
+  /// <summary>The internal ID for the recording's release in the CoverArt Archive.</summary>
+  /// <remarks>This field is only provided for the Year in Music 2022 and later.</remarks>
+  long? CoverArtId { get; }
+
+  /// <summary>The MusicBrainz ID for the recording's release in the CoverArt Archive.</summary>
+  /// <remarks>This field is only provided for the Year in Music 2022 and later.</remarks>
+  Guid? CoverArtReleaseGroupId { get; }
+
+  /// <summary>The MusicBrainz credits for the recording's artists.</summary>
+  /// <remarks>This field is only provided for the Year in Music 2023 and later.</remarks>
+  IReadOnlyList<IArtistCredit>? Credits { get; }
+
+  /// <summary>The MusicBrainz ID for the recording.</summary>
+  Guid? Id { get; }
+
+  /// <summary>The number of times the recording was listened to.</summary>
+  int ListenCount { get; }
+
+  /// <summary>The recording's name.</summary>
+  string Name { get; }
+
+  /// <summary>The MusicBrainz ID for the recording's release.</summary>
+  Guid? ReleaseId { get; }
+
+  /// <summary>The name of the recording's release.</summary>
+  string? ReleaseName { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/ITopRecording.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ITopRecording.cs
@@ -17,13 +17,13 @@ public interface ITopRecording : IJsonBasedObject {
   /// </summary>
   string? ArtistName { get; }
 
-  /// <summary>The internal ID for the recording's release in the CoverArt Archive.</summary>
+  /// <summary>The internal ID for the recording in the CoverArt Archive.</summary>
   /// <remarks>This field is only provided for the Year in Music 2022 and later.</remarks>
   long? CoverArtId { get; }
 
-  /// <summary>The MusicBrainz ID for the recording's release in the CoverArt Archive.</summary>
+  /// <summary>The MusicBrainz release ID for the recording in the CoverArt Archive.</summary>
   /// <remarks>This field is only provided for the Year in Music 2022 and later.</remarks>
-  Guid? CoverArtReleaseGroupId { get; }
+  Guid? CoverArtReleaseId { get; }
 
   /// <summary>The MusicBrainz credits for the recording's artists.</summary>
   /// <remarks>This field is only provided for the Year in Music 2023 and later.</remarks>

--- a/MetaBrainz.ListenBrainz/Interfaces/ITopRelease.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ITopRelease.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+
+using MetaBrainz.Common.Json;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>Information about one of a user's most listened to releases.</summary>
+public interface ITopRelease : IJsonBasedObject {
+
+  /// <summary>The MusicBrainz IDs for the release's credited artist(s).</summary>
+  IReadOnlyList<Guid>? ArtistIds { get; }
+
+  /// <summary>The release's credited artist name.</summary>
+  string? ArtistName { get; }
+
+  /// <summary>The internal ID for the release in the CoverArt Archive.</summary>
+  /// <remarks>This field is only provided for the Year in Music 2022.</remarks>
+  long? CoverArtId { get; }
+
+  /// <summary>The MusicBrainz ID for the release in the CoverArt Archive.</summary>
+  /// <remarks>This field is only provided for the Year in Music 2022.</remarks>
+  Guid? CoverArtReleaseGroupId { get; }
+
+  /// <summary>The MusicBrainz ID for the release, if available.</summary>
+  Guid? Id { get; }
+
+  /// <summary>The number of times the release's tracks were listened to.</summary>
+  int ListenCount { get; }
+
+  /// <summary>The release's name.</summary>
+  string Name { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/ITopRelease.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ITopRelease.cs
@@ -22,7 +22,7 @@ public interface ITopRelease : IJsonBasedObject {
   /// <remarks>This field is only provided for the Year in Music 2022.</remarks>
   Guid? CoverArtReleaseGroupId { get; }
 
-  /// <summary>The MusicBrainz ID for the release, if available.</summary>
+  /// <summary>The MusicBrainz ID for the releaserest ??= [ ];.</summary>
   Guid? Id { get; }
 
   /// <summary>The number of times the release's tracks were listened to.</summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/ITopRelease.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ITopRelease.cs
@@ -22,7 +22,7 @@ public interface ITopRelease : IJsonBasedObject {
   /// <remarks>This field is only provided for the Year in Music 2022.</remarks>
   Guid? CoverArtReleaseGroupId { get; }
 
-  /// <summary>The MusicBrainz ID for the releaserest ??= [ ];.</summary>
+  /// <summary>The MusicBrainz ID for the release.</summary>
   Guid? Id { get; }
 
   /// <summary>The number of times the release's tracks were listened to.</summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/ITopRelease.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ITopRelease.cs
@@ -18,9 +18,9 @@ public interface ITopRelease : IJsonBasedObject {
   /// <remarks>This field is only provided for the Year in Music 2022.</remarks>
   long? CoverArtId { get; }
 
-  /// <summary>The MusicBrainz ID for the release in the CoverArt Archive.</summary>
+  /// <summary>The MusicBrainz release ID for the release in the CoverArt Archive.</summary>
   /// <remarks>This field is only provided for the Year in Music 2022.</remarks>
-  Guid? CoverArtReleaseGroupId { get; }
+  Guid? CoverArtReleaseId { get; }
 
   /// <summary>The MusicBrainz ID for the release.</summary>
   Guid? Id { get; }

--- a/MetaBrainz.ListenBrainz/Interfaces/IYearInMusic.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IYearInMusic.cs
@@ -1,0 +1,14 @@
+﻿using MetaBrainz.Common.Json;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>Information about a user's "Year in Music".</summary>
+public interface IYearInMusic : IJsonBasedObject {
+
+  /// <summary>The "Year in Music" data.</summary>
+  IYearInMusicData Data { get; }
+
+  /// <summary>The user for whom the information was computed.</summary>
+  string User { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/IYearInMusicData.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IYearInMusicData.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 
 using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces.JSPF;
 
 namespace MetaBrainz.ListenBrainz.Interfaces;
 
@@ -69,7 +70,7 @@ public interface IYearInMusicData : IJsonBasedObject {
   IReadOnlyList<ITopArtist>? TopArtists { get; }
 
   /// <summary>Playlist for the "top discoveries for this year".</summary>
-  object? TopDiscoveriesPlaylist { get; }
+  IPlaylist? TopDiscoveriesPlaylist { get; }
 
   /// <summary>
   /// Mappings to CAA URLs for the recordings in <see cref="TopDiscoveriesPlaylist"/>.<br/>
@@ -83,7 +84,7 @@ public interface IYearInMusicData : IJsonBasedObject {
   IReadOnlyList<ITopGenre>? TopGenres { get; }
 
   /// <summary>Playlist for the "top missed recordings for this year".</summary>
-  object? TopMissedRecordingsPlaylist { get; }
+  IPlaylist? TopMissedRecordingsPlaylist { get; }
 
   /// <summary>
   /// Mappings to CAA URLs for the recordings in <see cref="TopMissedRecordingsPlaylist"/>.<br/>
@@ -94,7 +95,7 @@ public interface IYearInMusicData : IJsonBasedObject {
 
   /// <summary>Playlist for the "top new recordings for this year".</summary>
   /// <remarks>This field is only provided for the Year in Music 2021.</remarks>
-  object? TopNewRecordingsPlaylist { get; }
+  IPlaylist? TopNewRecordingsPlaylist { get; }
 
   /// <summary>
   /// Mappings to CAA URLs for the recordings in <see cref="TopNewRecordingsPlaylist"/>.<br/>
@@ -108,7 +109,7 @@ public interface IYearInMusicData : IJsonBasedObject {
 
   /// <summary>Playlist for the "top recordings for this year".</summary>
   /// <remarks>This field is only provided for the Year in Music 2021.</remarks>
-  object? TopRecordingsPlaylist { get; }
+  IPlaylist? TopRecordingsPlaylist { get; }
 
   /// <summary>
   /// Mappings to CAA URLs for the recordings in <see cref="TopRecordingsPlaylist"/>.<br/>

--- a/MetaBrainz.ListenBrainz/Interfaces/IYearInMusicData.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IYearInMusicData.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+
+using MetaBrainz.Common.Json;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>"Year in Music" data.</summary>
+/// <remarks>This data is not currently documented, so the field documentation is provisional.</remarks>
+public interface IYearInMusicData : IJsonBasedObject {
+
+  /// <summary>The total number of (distinct) artists listened to over the course of the year.</summary>
+  /// <remarks>This field is only provided for the Year in Music 2022 and later.</remarks>
+  int? ArtistCount { get; }
+
+  /// <summary>Information about artist listen counts, grouped by country.</summary>
+  /// <remarks>This field is only provided for the Year in Music 2022 and later.</remarks>
+  IReadOnlyList<IArtistCountryInfo>? ArtistMap { get; }
+
+  /// <summary>The weekday that sees the most listens recorded.</summary>
+  string? DayOfWeek { get; }
+
+  /// <summary>The total number of listens that were recorded over the course of the year.</summary>
+  int? ListenCount { get; }
+
+  /// <summary>The total amount of recorded listening time over the course of the year.</summary>
+  /// <remarks>This field is only provided for the Year in Music 2022 and later.</remarks>
+  TimeSpan? ListeningTime { get; }
+
+  /// <summary>The number of listens recorded on each day of the year.</summary>
+  IReadOnlyList<IListenTimeRange>? ListensPerDay { get; }
+
+  /// <summary>
+  /// Information about the number of listens for recordings released in a particular year.<br/>
+  /// The key is the release year, the value is the listen count.
+  /// </summary>
+  IReadOnlyDictionary<string, int>? MostListenedYear { get; }
+
+  /// <summary>The most prominent color on cover art associated with things the user listened to.</summary>
+  /// <remarks>This field is only provided for the Year in Music 2021.</remarks>
+  string? MostProminentColor { get; }
+
+  /// <summary>The total number of (distinct) new artists listened to over the course of the year.</summary>
+  /// <remarks>This field is only provided for the Year in Music 2022 and later.</remarks>
+  int? NewArtistsDiscovered { get; }
+
+  /// <summary>Information about new releases from the user's top artists.</summary>
+  IReadOnlyList<INewRelease>? NewReleasesOfTopArtists { get; }
+
+  /// <summary>The total number of (distinct) recordings (tracks) listened to over the course of the year.</summary>
+  /// <remarks>This field is only provided for the Year in Music 2022 and later.</remarks>
+  int? RecordingCount { get; }
+
+  /// <summary>The total number of (distinct) releases (albums) listened to over the course of the year.</summary>
+  /// <remarks>This field is only provided for the Year in Music 2022.</remarks>
+  int? ReleaseCount { get; }
+
+  /// <summary>The total number of (distinct) release groups (albums) listened to over the course of the year.</summary>
+  /// <remarks>This field is only provided for the Year in Music 2023 and later.</remarks>
+  int? ReleaseGroupCount { get; }
+
+  /// <summary>
+  /// Users with tastes similar to this one.<br/>
+  /// The key is the user ID, the value is the degree of similarity (between 0 and 1, so multiply by 100 for the percentage.
+  /// </summary>
+  IReadOnlyDictionary<string, decimal>? SimilarUsers { get; }
+
+  /// <summary>Information about a user's top artists.</summary>
+  IReadOnlyList<ITopArtist>? TopArtists { get; }
+
+  /// <summary>Playlist for the "top discoveries for this year".</summary>
+  object? TopDiscoveriesPlaylist { get; }
+
+  /// <summary>
+  /// Mappings to CAA URLs for the recordings in <see cref="TopDiscoveriesPlaylist"/>.<br/>
+  /// The key is the MusicBrainz ID for the recording, the value is the URL to an image from the CoverArt Archive.
+  /// </summary>
+  /// <remarks>This field is only provided for the Year in Music 2021 and 2022.</remarks>
+  IReadOnlyDictionary<string, Uri>? TopDiscoveriesPlaylistCoverArt { get; }
+
+  /// <summary>Information about a user's top genres.</summary>
+  /// <remarks>This field is only provided for the Year in Music 2023 and later.</remarks>
+  IReadOnlyList<ITopGenre>? TopGenres { get; }
+
+  /// <summary>Playlist for the "top missed recordings for this year".</summary>
+  object? TopMissedRecordingsPlaylist { get; }
+
+  /// <summary>
+  /// Mappings to CAA URLs for the recordings in <see cref="TopMissedRecordingsPlaylist"/>.<br/>
+  /// The key is the MusicBrainz ID for the recording, the value is the URL to an image from the CoverArt Archive.
+  /// </summary>
+  /// <remarks>This field is only provided for the Year in Music 2021 and 2022.</remarks>
+  IReadOnlyDictionary<string, Uri>? TopMissedRecordingsPlaylistCoverArt { get; }
+
+  /// <summary>Playlist for the "top new recordings for this year".</summary>
+  /// <remarks>This field is only provided for the Year in Music 2021.</remarks>
+  object? TopNewRecordingsPlaylist { get; }
+
+  /// <summary>
+  /// Mappings to CAA URLs for the recordings in <see cref="TopNewRecordingsPlaylist"/>.<br/>
+  /// The key is the MusicBrainz ID for the recording, the value is the URL to an image from the CoverArt Archive.
+  /// </summary>
+  /// <remarks>This field is only provided for the Year in Music 2021.</remarks>
+  IReadOnlyDictionary<string, Uri>? TopNewRecordingsPlaylistCoverArt { get; }
+
+  /// <summary>Information about a user's top recordings (tracks).</summary>
+  IReadOnlyList<ITopRecording>? TopRecordings { get; }
+
+  /// <summary>Playlist for the "top recordings for this year".</summary>
+  /// <remarks>This field is only provided for the Year in Music 2021.</remarks>
+  object? TopRecordingsPlaylist { get; }
+
+  /// <summary>
+  /// Mappings to CAA URLs for the recordings in <see cref="TopRecordingsPlaylist"/>.<br/>
+  /// The key is the MusicBrainz ID for the recording, the value is the URL to an image from the CoverArt Archive.
+  /// </summary>
+  /// <remarks>This field is only provided for the Year in Music 2021.</remarks>
+  IReadOnlyDictionary<string, Uri>? TopRecordingsPlaylistCoverArt { get; }
+
+  /// <summary>Information about a user's top release groups (albums).</summary>
+  /// <remarks>This field is only provided for the Year in Music 2023 and later.</remarks>
+  IReadOnlyList<IReleaseGroupInfo>? TopReleaseGroups { get; }
+
+  /// <summary>Information about a user's top releases (albums).</summary>
+  /// <remarks>This field is only provided for the Year in Music 2021 and 2022.</remarks>
+  IReadOnlyList<ITopRelease>? TopReleases { get; }
+
+  /// <summary>
+  /// Mappings to CAA URLs for the releases in <see cref="TopReleases"/>.<br/>
+  /// The key is the MusicBrainz ID for the release (as found in <see cref="TopReleases"/>), the value is the URL to an image from
+  /// the CoverArt Archive.
+  /// </summary>
+  /// <remarks>This field is only provided for the Year in Music 2021.</remarks>
+  IReadOnlyDictionary<string, Uri>? TopReleasesCoverArt { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/JSPF/ILink.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/JSPF/ILink.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace MetaBrainz.ListenBrainz.Interfaces.JSPF;
+
+/// <summary>A resource link.</summary>
+public interface ILink {
+
+  /// <summary>The URI identifying the resource type.</summary>
+  Uri Id { get; }
+
+  /// <summary>The URI identifying the resource.</summary>
+  Uri Value { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/JSPF/IMeta.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/JSPF/IMeta.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace MetaBrainz.ListenBrainz.Interfaces.JSPF;
+
+/// <summary>A metadata item.</summary>
+public interface IMeta {
+
+  /// <summary>The URI identifying the metadata.</summary>
+  Uri Id { get; }
+
+  /// <summary>The value for the metadata.</summary>
+  string Value { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/JSPF/IMusicBrainzPlaylist.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/JSPF/IMusicBrainzPlaylist.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace MetaBrainz.ListenBrainz.Interfaces.JSPF;
+
+/// <summary>Additional information for a playlist, as defined by MusicBrainz.</summary>
+/// <seealso href="https://musicbrainz.org/doc/jspf#playlist"/>
+public interface IMusicBrainzPlaylist {
+
+  /// <summary>
+  /// Additional playlist metadata that may be used by playlist generation tools. The contents are defined by those playlist
+  /// generation tools.
+  /// </summary>
+  IReadOnlyDictionary<string, object?>? AdditionalMetadata { get; }
+
+  /// <summary>Who are the ListenBrainz users who have access to edit this playlist?</summary>
+  IReadOnlyList<string>? Collaborators { get; }
+
+  /// <summary>If this playlist was copied from an existing playlist, this identifies that original playlist.</summary>
+  Uri? CopiedFrom { get; }
+
+  /// <summary>
+  /// Indicates that this playlist was copied from an existing playlist, but the original playlist has been deleted, so
+  /// <see cref="CopiedFrom"/> cannot be provided.
+  /// </summary>
+  bool? CopiedFromDeleted { get; }
+
+  /// <summary>Which ListenBrainz user was the playlist generated for?</summary>
+  /// <remarks>This is for music recommendation bots generating playlists for users.</remarks>
+  string? CreatedFor { get; }
+
+  /// <summary>The ListenBrainz user who created this playlist.</summary>
+  string? Creator { get; }
+
+  /// <summary>The timestamp for when this playlist was last modified.</summary>
+  DateTimeOffset? LastModified { get; }
+
+  /// <summary>Indicates whether this playlist is public or private.</summary>
+  bool? Public { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/JSPF/IMusicBrainzRecording.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/JSPF/IMusicBrainzRecording.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace MetaBrainz.ListenBrainz.Interfaces.JSPF;
+
+/// <summary>Information about a MusicBrainz recording, associated with a track on a playlist.</summary>
+public interface IMusicBrainzRecording {
+
+  /// <summary>The MusicBrainz IDs for the recording's artist(s).</summary>
+  IReadOnlyList<Guid>? ArtistIds { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/JSPF/IMusicBrainzTrack.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/JSPF/IMusicBrainzTrack.cs
@@ -24,10 +24,10 @@ public interface IMusicBrainzTrack : IJsonBasedObject {
   /// <summary>MusicBrainz artist URIs that identify the track's credited artist(s).</summary>
   IReadOnlyList<Uri>? ArtistIds { get; }
 
-  /// <summary>The internal ID for the track's release in the CoverArt Archive.</summary>
+  /// <summary>The internal ID for the track in the CoverArt Archive.</summary>
   long? CoverArtId { get; }
 
-  /// <summary>The MusicBrainz ID for the track's release in the CoverArt Archive.</summary>
+  /// <summary>The MusicBrainz release ID for the track in the CoverArt Archive.</summary>
   Guid? CoverArtReleaseId { get; }
 
   /// <summary>The MusicBrainz credits for the track's artists.</summary>

--- a/MetaBrainz.ListenBrainz/Interfaces/JSPF/IMusicBrainzTrack.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/JSPF/IMusicBrainzTrack.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+
+using MetaBrainz.Common.Json;
+
+namespace MetaBrainz.ListenBrainz.Interfaces.JSPF;
+
+/// <summary>Additional information for a track on a playlist, as defined by MusicBrainz.</summary>
+/// <seealso href="https://musicbrainz.org/doc/jspf#track"/>
+public interface IMusicBrainzTrack : IJsonBasedObject {
+
+  /// <summary>The timestamp for when this track was added to the playlist.</summary>
+  DateTimeOffset? Added { get; }
+
+  /// <summary>The ListenBrainz user who added this track.</summary>
+  string? AddedBy { get; }
+
+  /// <summary>
+  /// Additional playlist metadata that may be used by playlist generation tools. The contents are defined by those playlist
+  /// generation tools.
+  /// </summary>
+  IReadOnlyDictionary<string, object?>? AdditionalMetadata { get; }
+
+  /// <summary>MusicBrainz artist URIs that identify the track's credited artist(s).</summary>
+  IReadOnlyList<Uri>? ArtistIds { get; }
+
+  /// <summary>The internal ID for the track's release in the CoverArt Archive.</summary>
+  long? CoverArtId { get; }
+
+  /// <summary>The MusicBrainz ID for the track's release in the CoverArt Archive.</summary>
+  Guid? CoverArtReleaseId { get; }
+
+  /// <summary>The MusicBrainz credits for the track's artists.</summary>
+  IReadOnlyList<IArtistCredit>? Credits { get; }
+
+  /// <summary>The MusicBrainz release URI for the release containing this track.</summary>
+  Uri? ReleaseId { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/JSPF/INamedUri.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/JSPF/INamedUri.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace MetaBrainz.ListenBrainz.Interfaces.JSPF;
+
+/// <summary>A named URI.</summary>
+public interface INamedUri {
+
+  /// <summary>The name associated with the URI.</summary>
+  string Name { get; }
+
+  /// <summary>The URI.</summary>
+  Uri Uri { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/JSPF/IPlaylist.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/JSPF/IPlaylist.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+
+using MetaBrainz.Common.Json;
+
+namespace MetaBrainz.ListenBrainz.Interfaces.JSPF;
+
+/// <summary>A JSPF playlist (with MusicBrainz extensions).</summary>
+public interface IPlaylist : IJsonBasedObject {
+
+  /// <summary>A comment associated with the playlist.</summary>
+  string? Annotation { get; }
+
+  /// <summary>A list of named URIs, intended to satisfy licenses that allow modification but require attribution.</summary>
+  IReadOnlyList<INamedUri>? Attribution { get; }
+
+  /// <summary>The name of the entity that authored the playlist.</summary>
+  string? Creator { get; }
+
+  /// <summary>The creation date of the playlist.</summary>
+  DateTimeOffset? Date { get; }
+
+  /// <summary>
+  /// Additional arbitrary data associated with this playlist.<br/>
+  /// The key is a URI identifying the application that created the data; the value is a list of arbitrary elements.
+  /// </summary>
+  IReadOnlyDictionary<Uri, IReadOnlyList<object?>?>? Extensions { get; }
+
+  /// <summary>The canonical ID for this playlist.</summary>
+  Uri? Identifier { get; }
+
+  /// <summary>URI of an image associated with this playlist.</summary>
+  Uri? Image { get; }
+
+  /// <summary>URI of a web page where one can find out more about this playlist.</summary>
+  Uri? Info { get; }
+
+  /// <summary>The license under which this playlist was released.</summary>
+  Uri? License { get; }
+
+  /// <summary>Links to resources associated with the playlist.</summary>
+  IReadOnlyList<ILink>? Links { get; }
+
+  /// <summary>Source URI for this playlist.</summary>
+  Uri? Location { get; }
+
+  /// <summary>Metadata associated with the playlist.</summary>
+  IReadOnlyList<IMeta>? Metadata { get; }
+
+  /// <summary>The playlist's title.</summary>
+  string? Title { get; }
+
+  /// <summary>The tracks included in the playlist.</summary>
+  IReadOnlyList<ITrack> Tracks { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/JSPF/IPlaylist.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/JSPF/IPlaylist.cs
@@ -47,6 +47,9 @@ public interface IPlaylist : IJsonBasedObject {
   /// <summary>Metadata associated with the playlist.</summary>
   IReadOnlyList<IMeta>? Metadata { get; }
 
+  /// <summary>MusicBrainz-specific information about the playlist.</summary>
+  IMusicBrainzPlaylist? MusicBrainz { get; }
+
   /// <summary>The playlist's title.</summary>
   string? Title { get; }
 

--- a/MetaBrainz.ListenBrainz/Interfaces/JSPF/ITrack.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/JSPF/ITrack.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+
+using MetaBrainz.Common.Json;
+
+namespace MetaBrainz.ListenBrainz.Interfaces.JSPF;
+
+/// <summary>Information about a track in a JSPF playlist (with MusicBrainz extensions).</summary>
+public interface ITrack : IJsonBasedObject {
+
+  /// <summary>The name of the collection from which the track was taken.</summary>
+  string? Album { get; }
+
+  /// <summary>A comment associated with the track.</summary>
+  string? Annotation { get; }
+
+  /// <summary>The name of the entity that authored the track.</summary>
+  string? Creator { get; }
+
+  /// <summary>The duration of the track.</summary>
+  TimeSpan? Duration { get; }
+
+  /// <summary>
+  /// Additional arbitrary data associated with this playlist.<br/>
+  /// The key is a URI identifying the application that created the data; the value is a list of arbitrary elements.
+  /// </summary>
+  IReadOnlyDictionary<Uri, IReadOnlyList<object?>?>? Extensions { get; }
+
+  /// <summary>Canonical identifiers for this track.</summary>
+  IReadOnlyList<Uri>? Identifiers { get; }
+
+  /// <summary>URI of an image associated with this playlist.</summary>
+  Uri? Image { get; }
+
+  /// <summary>URI of a web page where one can purchase and/or find out more about this track.</summary>
+  Uri? Info { get; }
+
+  /// <summary>Links to resources associated with the track.</summary>
+  IReadOnlyList<ILink>? Links { get; }
+
+  /// <summary>
+  /// A number of URIs where the track can be found (e.g. URLs pointing to lossless and lossy versions of the audio).
+  /// </summary>
+  IReadOnlyList<Uri>? Locations { get; }
+
+  /// <summary>Metadata associated with the track.</summary>
+  IReadOnlyList<IMeta>? Metadata { get; }
+
+  /// <summary>The track title.</summary>
+  string? Title { get; }
+
+  /// <summary>The ordinal position (with 1 being the first element) of the track within <see cref="Album"/>.</summary>
+  uint? TrackNumber { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/JSPF/ITrack.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/JSPF/ITrack.cs
@@ -46,6 +46,13 @@ public interface ITrack : IJsonBasedObject {
   /// <summary>Metadata associated with the track.</summary>
   IReadOnlyList<IMeta>? Metadata { get; }
 
+  /// <summary>MusicBrainz-specific information about the track.</summary>
+  IMusicBrainzTrack? MusicBrainz { get; }
+
+  /// <summary>MusicBrainz-specific information about the track.</summary>
+  /// <remarks>This is only returned for old playlists, like those that are part of the Year in Music data for 2021.</remarks>
+  IMusicBrainzRecording? MusicBrainzRecording { get; }
+
   /// <summary>The track title.</summary>
   string? Title { get; }
 

--- a/MetaBrainz.ListenBrainz/Json/Converters.cs
+++ b/MetaBrainz.ListenBrainz/Json/Converters.cs
@@ -29,6 +29,7 @@ internal static class Converters {
       yield return ReleaseStatisticsReader.Instance;
       yield return TokenValidationResultReader.Instance;
       yield return UserDailyActivityReader.Instance;
+      yield return YearInMusicReader.Instance;
     }
   }
 

--- a/MetaBrainz.ListenBrainz/Json/Readers/AlbumInfoReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/AlbumInfoReader.cs
@@ -32,7 +32,7 @@ internal class AlbumInfoReader : ObjectReader<AlbumInfo> {
             mbid = reader.GetOptionalGuid();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/AristEvolutionActivityReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/AristEvolutionActivityReader.cs
@@ -52,7 +52,7 @@ internal sealed class ArtistEvolutionActivityReader : PayloadReader<ArtistEvolut
             user = reader.GetString();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/ArtistActivityInfoReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ArtistActivityInfoReader.cs
@@ -41,7 +41,7 @@ internal class ArtistActivityInfoReader : ObjectReader<ArtistActivityInfo> {
             name = reader.GetString();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }
@@ -53,7 +53,7 @@ internal class ArtistActivityInfoReader : ObjectReader<ArtistActivityInfo> {
     }
     // Retain artist_name (as unhandled) only if it's not a duplicate of the name
     if (artistName is not null && artistName != name) {
-      rest ??= new Dictionary<string, object?>();
+      rest ??= [ ];
       rest["artist_name"] = artistName;
     }
     return new ArtistActivityInfo {

--- a/MetaBrainz.ListenBrainz/Json/Readers/ArtistActivityReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ArtistActivityReader.cs
@@ -24,7 +24,7 @@ internal class ArtistActivityReader : ObjectReader<ArtistActivity> {
             artists = reader.ReadList(ArtistActivityInfoReader.Instance, options);
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/ArtistCountryInfoReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ArtistCountryInfoReader.cs
@@ -37,7 +37,7 @@ internal class ArtistCountryInfoReader : ObjectReader<ArtistCountryInfo> {
             listenCount = reader.GetInt32();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/ArtistCreditReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ArtistCreditReader.cs
@@ -32,7 +32,7 @@ internal class ArtistCreditReader : ObjectReader<ArtistCredit> {
             joinPhrase = reader.GetString();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/ArtistInfoReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ArtistInfoReader.cs
@@ -40,7 +40,7 @@ internal class ArtistInfoReader : ObjectReader<ArtistInfo> {
             listenCount = reader.GetInt32();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/ArtistListenersReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ArtistListenersReader.cs
@@ -64,7 +64,7 @@ internal sealed class ArtistListenersReader : PayloadReader<ArtistListeners> {
             totalListeners = reader.GetInt32();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/ArtistMapReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ArtistMapReader.cs
@@ -52,7 +52,7 @@ internal sealed class ArtistMapReader : PayloadReader<ArtistMap> {
             user = reader.GetString();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/ArtistStatisticsReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ArtistStatisticsReader.cs
@@ -64,7 +64,7 @@ internal sealed class ArtistStatisticsReader : PayloadReader<ArtistStatistics> {
             user = reader.GetString();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/ArtistTimeRangeReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ArtistTimeRangeReader.cs
@@ -39,7 +39,7 @@ internal class ArtistTimeRangeReader : ObjectReader<ArtistTimeRange> {
             break;
           }
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/DailyActivityReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/DailyActivityReader.cs
@@ -49,7 +49,7 @@ internal sealed class DailyActivityReader : ObjectReader<DailyActivity> {
             sunday = reader.ReadList(HourlyActivityReader.Instance, options);
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/EraActivityReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/EraActivityReader.cs
@@ -52,7 +52,7 @@ internal sealed class EraActivityReader : PayloadReader<EraActivity> {
             user = reader.GetString();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/ErrorInfoReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ErrorInfoReader.cs
@@ -28,7 +28,7 @@ internal sealed class ErrorInfoReader : ObjectReader<ErrorInfo> {
             error = reader.GetString();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/FetchedListensReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/FetchedListensReader.cs
@@ -40,7 +40,7 @@ internal sealed class FetchedListensReader : PayloadReader<FetchedListens> {
             user = reader.GetString();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/GenreActivityDetailsReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/GenreActivityDetailsReader.cs
@@ -32,7 +32,7 @@ internal sealed class GenreActivityDetailsReader : ObjectReader<GenreActivityDet
             listenCount = reader.GetInt32();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/GenreActivityReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/GenreActivityReader.cs
@@ -25,7 +25,7 @@ internal sealed class GenreActivityReader : ObjectReader<GenreActivity> {
             activity = reader.ReadList(GenreActivityDetailsReader.Instance, options);
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/HourlyActivityReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/HourlyActivityReader.cs
@@ -28,7 +28,7 @@ internal sealed class HourlyActivityReader : ObjectReader<HourlyActivity> {
             listenCount = reader.GetInt32();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/JSPF/Helpers.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/JSPF/Helpers.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.Common.Json.Converters;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers.JSPF;
+
+using ExtensionData = IReadOnlyDictionary<Uri, IReadOnlyList<object?>?>;
+
+internal static class Helpers {
+
+  public static ExtensionData? ReadExtensions(this ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    if (reader.TokenType == JsonTokenType.Null) {
+      return null;
+    }
+    if (reader.TokenType != JsonTokenType.StartObject) {
+      throw new JsonException("Expected start of extension data not found.");
+    }
+    reader.Read();
+    Dictionary<Uri, IReadOnlyList<object?>?> extensions = [ ];
+    while (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      try {
+        if (!Uri.TryCreate(prop, UriKind.Absolute, out var id)) {
+          throw new JsonException($"The extension application identifier ({prop}) is not a valid URI.");
+        }
+        reader.Read();
+        if (reader.TokenType == JsonTokenType.StartObject) {
+          // LB-1836: this is a violation of the JSPF spec, but it's what ListenBrainz currently does.
+          extensions.Add(id, [reader.GetOptionalObject(options)]);
+        }
+        else {
+          extensions.Add(id, reader.ReadList(AnyObjectReader.Instance, options));
+        }
+      }
+      catch (Exception e) {
+        throw new JsonException($"Failed to deserialize the data for the '{prop}' extension.", e);
+      }
+      reader.Read();
+    }
+    if (reader.TokenType != JsonTokenType.EndObject) {
+      throw new JsonException("Expected end of extension data not found.");
+    }
+    return extensions;
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Readers/JSPF/LinkReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/JSPF/LinkReader.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.Common.Json.Converters;
+using MetaBrainz.ListenBrainz.Objects.JSPF;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers.JSPF;
+
+internal sealed class LinkReader : ObjectReader<Link> {
+
+  public static readonly LinkReader Instance = new();
+
+  protected override Link ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    // This is expected to have a single property, where the name is the resource type URI and the value is the resource URI.
+    if (reader.TokenType != JsonTokenType.PropertyName) {
+      throw new JsonException("The (single) property is missing.");
+    }
+    var prop = reader.GetPropertyName();
+    if (!Uri.TryCreate(prop, UriKind.Absolute, out var id)) {
+      throw new JsonException($"The link identifier ({prop}) is not a valid URI.");
+    }
+    reader.Read();
+    var value = reader.GetUri();
+    if (reader.TokenType != JsonTokenType.EndObject) {
+      throw new JsonException("Excess contents encountered.");
+    }
+    return new Link { Id = id, Value = value, };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Readers/JSPF/MetaReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/JSPF/MetaReader.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.Common.Json.Converters;
+using MetaBrainz.ListenBrainz.Objects.JSPF;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers.JSPF;
+
+internal sealed class MetaReader : ObjectReader<Meta> {
+
+  public static readonly MetaReader Instance = new();
+
+  protected override Meta ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    // This is expected to have a single property, where the name is the metadata type URI and the value is the plain text metadata.
+    if (reader.TokenType != JsonTokenType.PropertyName) {
+      throw new JsonException("The (single) property is missing.");
+    }
+    var prop = reader.GetPropertyName();
+    if (!Uri.TryCreate(prop, UriKind.Absolute, out var id)) {
+      throw new JsonException($"The link identifier ({prop}) is not a valid URI.");
+    }
+    reader.Read();
+    var value = reader.GetString() ?? "";
+    if (reader.TokenType != JsonTokenType.EndObject) {
+      throw new JsonException("Excess contents encountered.");
+    }
+    return new Meta { Id = id, Value = value, };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Readers/JSPF/MusicBrainzPlaylistReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/JSPF/MusicBrainzPlaylistReader.cs
@@ -75,7 +75,7 @@ internal class MusicBrainzPlaylistReader : ObjectReader<MusicBrainzPlaylist> {
         additionalMetadata = new Dictionary<string, object?> { { "algorithm_metadata", algorithmMetadata } };
       }
       else {
-        rest ??= [];
+        rest ??= [ ];
         rest["algorithm_metadata"] = algorithmMetadata;
       }
     }

--- a/MetaBrainz.ListenBrainz/Json/Readers/JSPF/MusicBrainzPlaylistReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/JSPF/MusicBrainzPlaylistReader.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.Common.Json.Converters;
+using MetaBrainz.ListenBrainz.Interfaces.JSPF;
+using MetaBrainz.ListenBrainz.Objects.JSPF;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers.JSPF;
+
+internal class MusicBrainzPlaylistReader : ObjectReader<MusicBrainzPlaylist> {
+
+  public static readonly MusicBrainzPlaylistReader Instance = new();
+
+  protected override MusicBrainzPlaylist ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    IReadOnlyDictionary<string, object?>? additionalMetadata = null;
+    IReadOnlyDictionary<string, object?>? algorithmMetadata = null;
+    IReadOnlyList<string>? collaborators = null;
+    Uri? copiedFrom = null;
+    bool? copiedFromDeleted = null;
+    string? createdFor = null;
+    string? creator = null;
+    bool? isPublic = null;
+    DateTimeOffset? lastModified = null;
+    Dictionary<string, object?>? rest = null;
+    while (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      try {
+        reader.Read();
+        switch (prop) {
+          case "additional_metadata":
+            additionalMetadata = reader.ReadDictionary(OptionalObjectReader.Instance, options);
+            break;
+          case "algorithm_metadata":
+            algorithmMetadata = reader.ReadDictionary(OptionalObjectReader.Instance, options);
+            break;
+          case "collaborators":
+            collaborators = reader.ReadList<string>(options);
+            break;
+          case "copied_from":
+            copiedFrom = reader.GetOptionalUri();
+            break;
+          case "copied_from_deleted":
+            copiedFromDeleted = reader.GetOptionalBoolean();
+            break;
+          case "created_for":
+            createdFor = reader.GetString();
+            break;
+          case "creator":
+            creator = reader.GetString();
+            break;
+          case "last_modified_at":
+            lastModified = reader.GetOptionalDateTimeOffset();
+            break;
+          case "public":
+            isPublic = reader.GetOptionalBoolean();
+            break;
+          default:
+            rest ??= [ ];
+            rest[prop] = reader.GetOptionalObject(options);
+            break;
+        }
+      }
+      catch (Exception e) {
+        throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+      }
+      reader.Read();
+    }
+    // The 2021 Year in Music playlists have algorithm_metadata but not additional_metadata. The 2022 editions have
+    // algorithm_metadata as a property of additional_metadata. Adjust the 2021 case to look like the 2022 case; but if both
+    // metadata fields are present, consider algorithm_metadata to be unhandled.
+    if (algorithmMetadata is not null) {
+      if (additionalMetadata is null) {
+        additionalMetadata = new Dictionary<string, object?> { { "algorithm_metadata", algorithmMetadata } };
+      }
+      else {
+        rest ??= [];
+        rest["algorithm_metadata"] = algorithmMetadata;
+      }
+    }
+    return new MusicBrainzPlaylist {
+      AdditionalMetadata = additionalMetadata,
+      Collaborators = collaborators,
+      CopiedFrom = copiedFrom,
+      CopiedFromDeleted = copiedFromDeleted,
+      CreatedFor = createdFor,
+      Creator = creator,
+      LastModified = lastModified,
+      Public = isPublic,
+      UnhandledProperties = rest,
+    };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Readers/JSPF/MusicBrainzRecordingReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/JSPF/MusicBrainzRecordingReader.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.Common.Json.Converters;
+using MetaBrainz.ListenBrainz.Interfaces.JSPF;
+using MetaBrainz.ListenBrainz.Objects.JSPF;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers.JSPF;
+
+internal class MusicBrainzRecordingReader : ObjectReader<MusicBrainzRecording> {
+
+  public static readonly MusicBrainzRecordingReader Instance = new();
+
+  protected override MusicBrainzRecording ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    IReadOnlyList<Guid>? artistIds = null;
+    Dictionary<string, object?>? rest = null;
+    while (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      try {
+        reader.Read();
+        switch (prop) {
+          case "artist_mbids":
+            artistIds = reader.ReadList<Guid>(options);
+            break;
+          default:
+            rest ??= [ ];
+            rest[prop] = reader.GetOptionalObject(options);
+            break;
+        }
+      }
+      catch (Exception e) {
+        throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+      }
+      reader.Read();
+    }
+    return new MusicBrainzRecording {
+      ArtistIds = artistIds,
+      UnhandledProperties = rest,
+    };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Readers/JSPF/MusicBrainzTrackReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/JSPF/MusicBrainzTrackReader.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.Common.Json.Converters;
+using MetaBrainz.ListenBrainz.Interfaces;
+using MetaBrainz.ListenBrainz.Interfaces.JSPF;
+using MetaBrainz.ListenBrainz.Objects.JSPF;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers.JSPF;
+
+internal class MusicBrainzTrackReader : ObjectReader<MusicBrainzTrack> {
+
+  public static readonly MusicBrainzTrackReader Instance = new();
+
+  protected override MusicBrainzTrack ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    DateTimeOffset? added = null;
+    string? addedBy = null;
+    Dictionary<string, object?>? additionalMetadata = null;
+    IReadOnlyList<Uri>? artistIds = null;
+    long? caaId = null;
+    Guid? caaRelease = null;
+    IReadOnlyList<IArtistCredit>? credits = null;
+    Uri? releaseId = null;
+    Dictionary<string, object?>? rest = null;
+    while (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      try {
+        reader.Read();
+        switch (prop) {
+          case "added_at":
+            added = reader.GetOptionalDateTimeOffset();
+            break;
+          case "added_by":
+            addedBy = reader.GetString();
+            break;
+          case "additional_metadata":
+            if (reader.TokenType == JsonTokenType.Null) {
+              additionalMetadata = null;
+            }
+            else if (reader.TokenType == JsonTokenType.StartObject) {
+              reader.Read();
+              while (reader.TokenType == JsonTokenType.PropertyName) {
+                var key = reader.GetPropertyName();
+                reader.Read();
+                try {
+                  switch (key) {
+                    case "artists":
+                      credits = reader.ReadList(ArtistCreditReader.Instance, options);
+                      break;
+                    case "caa_id":
+                      caaId = reader.GetOptionalInt64();
+                      break;
+                    case "caa_release_mbid":
+                      caaRelease = reader.GetOptionalGuid();
+                      break;
+                    default:
+                      // not a well-known value, so store it generically
+                      additionalMetadata ??= [];
+                      additionalMetadata.Add(key, reader.GetOptionalObject(AnyObjectReader.Instance, options));
+                      break;
+                  }
+                }
+                catch (Exception e) {
+                  throw new JsonException($"Failed to deserialize additional metadata item '{key}'.", e);
+                }
+                reader.Read();
+              }
+              if (reader.TokenType != JsonTokenType.EndObject) {
+                throw new JsonException("Expected end of dictionary not found.");
+              }
+            }
+            else {
+              throw new JsonException("Expected start of dictionary not found.");
+            }
+            break;
+          case "artist_identifiers":
+            artistIds = reader.ReadList<Uri>(options);
+            break;
+          case "release_identifier":
+            releaseId = reader.GetOptionalUri();
+            break;
+          default:
+            rest ??= [ ];
+            rest[prop] = reader.GetOptionalObject(options);
+            break;
+        }
+      }
+      catch (Exception e) {
+        throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+      }
+      reader.Read();
+    }
+    return new MusicBrainzTrack {
+      Added = added,
+      AddedBy = addedBy,
+      AdditionalMetadata = additionalMetadata,
+      ArtistIds = artistIds,
+      CoverArtId = caaId,
+      CoverArtReleaseId = caaRelease,
+      Credits = credits,
+      ReleaseId = releaseId,
+      UnhandledProperties = rest,
+    };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Readers/JSPF/NamedUriReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/JSPF/NamedUriReader.cs
@@ -1,0 +1,27 @@
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.Common.Json.Converters;
+using MetaBrainz.ListenBrainz.Objects.JSPF;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers.JSPF;
+
+internal sealed class NamedUriReader : ObjectReader<NamedUri> {
+
+  public static readonly NamedUriReader Instance = new();
+
+  protected override NamedUri ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    // This is expected to have a single property, where the property name is the name and the value is the URI.
+    if (reader.TokenType != JsonTokenType.PropertyName) {
+      throw new JsonException("The (single) property is missing.");
+    }
+    var name = reader.GetPropertyName();
+    reader.Read();
+    var uri = reader.GetUri();
+    if (reader.TokenType != JsonTokenType.EndObject) {
+      throw new JsonException("Excess contents encountered.");
+    }
+    return new NamedUri { Name = name, Uri = uri, };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Readers/JSPF/PlaylistReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/JSPF/PlaylistReader.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.Common.Json.Converters;
+using MetaBrainz.ListenBrainz.Interfaces.JSPF;
+using MetaBrainz.ListenBrainz.Objects.JSPF;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers.JSPF;
+
+internal class PlaylistReader : ObjectReader<Playlist> {
+
+  public static readonly PlaylistReader Instance = new();
+
+  protected override Playlist ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    Dictionary<string, object?>? rest = null;
+    return this.ReadPlaylist(ref reader, options, ref rest);
+  }
+
+  private Playlist ReadObjectForPlaylist(ref Utf8JsonReader reader, JsonSerializerOptions options,
+                                      ref Dictionary<string, object?>? rest) {
+    if (reader.TokenType != JsonTokenType.StartObject) {
+      throw new JsonException("Expected start of playlist object not found.");
+    }
+    reader.Read();
+    var playlist = this.ReadPlaylist(ref reader, options, ref rest);
+    if (reader.TokenType != JsonTokenType.EndObject) {
+      throw new JsonException("Expected end of playlist data not found.");
+    }
+    return playlist;
+  }
+
+  private Playlist ReadPlaylist(ref Utf8JsonReader reader, JsonSerializerOptions options, ref Dictionary<string, object?>? rest) {
+    if (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      // Check for the ListenBrainz envelope: { jspf: <playlist>, mbid: guid }
+      if (prop is "jspf" or "mbid") {
+        Playlist? playlist = null;
+        while (reader.TokenType == JsonTokenType.PropertyName) {
+          prop = reader.GetPropertyName();
+          try {
+            reader.Read();
+            switch (prop) {
+              case "jspf":
+                playlist = this.ReadObjectForPlaylist(ref reader, options, ref rest);
+                break;
+              case "mbid":
+                rest ??= [ ];
+                rest["listenbrainz:mbid"] = reader.GetGuid();
+                break;
+              default:
+                rest ??= [ ];
+                rest[prop] = reader.GetOptionalObject(options);
+                break;
+            }
+          }
+          catch (Exception e) {
+            throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+          }
+          reader.Read();
+        }
+        if (playlist is null) {
+          throw new JsonException("Expected 'jspf' property not found.");
+        }
+        return playlist;
+      }
+      // Check for the outer JSPF layer: { playlist: <playlist> }
+      if (prop is "playlist") {
+        reader.Read();
+        var playlist = this.ReadObjectForPlaylist(ref reader, options, ref rest);
+        reader.Read();
+        while (reader.TokenType == JsonTokenType.PropertyName) {
+          prop = reader.GetPropertyName();
+          try {
+            reader.Read();
+            rest ??= [ ];
+            rest[$"playlist-wrapper:{prop}"] = reader.GetOptionalObject(options);
+          }
+          catch (Exception e) {
+            throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+          }
+          reader.Read();
+        }
+        return playlist;
+      }
+    }
+    string? annotation = null;
+    IReadOnlyList<INamedUri>? attribution = null;
+    DateTimeOffset? date = null;
+    string? creator = null;
+    IReadOnlyDictionary<Uri, IReadOnlyList<object?>?>? extensions = null;
+    Uri? identifier = null;
+    Uri? image = null;
+    Uri? info = null;
+    Uri? license = null;
+    IReadOnlyList<ILink>? links = null;
+    Uri? location = null;
+    IReadOnlyList<IMeta>? meta = null;
+    string? title = null;
+    IReadOnlyList<ITrack>? tracks = null;
+    while (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      try {
+        reader.Read();
+        switch (prop) {
+          case "annotation":
+            annotation = reader.GetString();
+            break;
+          case "attribution":
+            attribution = reader.ReadList(NamedUriReader.Instance, options);
+            break;
+          case "creator":
+            creator = reader.GetString();
+            break;
+          case "date":
+            date = reader.GetDateTimeOffset();
+            break;
+          case "extension":
+            extensions = reader.ReadExtensions(options);
+            break;
+          case "identifier":
+            identifier = reader.GetOptionalUri();
+            break;
+          case "image":
+            image = reader.GetOptionalUri();
+            break;
+          case "info":
+            info = reader.GetOptionalUri();
+            break;
+          case "license":
+            license = reader.GetOptionalUri();
+            break;
+          case "link":
+            links = reader.ReadList(LinkReader.Instance, options);
+            break;
+          case "location":
+            location = reader.GetOptionalUri();
+            break;
+          case "meta":
+            meta = reader.ReadList(MetaReader.Instance, options);
+            break;
+          case "title":
+            title = reader.GetString();
+            break;
+          case "track":
+            tracks = reader.ReadList(TrackReader.Instance, options);
+            break;
+          default:
+            rest ??= [ ];
+            rest[prop] = reader.GetOptionalObject(options);
+            break;
+        }
+      }
+      catch (Exception e) {
+        throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+      }
+      reader.Read();
+    }
+    return new Playlist {
+      Annotation = annotation,
+      Attribution = attribution,
+      Date = date,
+      Creator = creator,
+      Extensions = extensions,
+      Identifier = identifier,
+      Image = image,
+      Info = info,
+      License = license,
+      Links = links,
+      Location = location,
+      Metadata = meta,
+      Title = title,
+      Tracks = tracks ?? [ ],
+      UnhandledProperties = rest,
+    };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Readers/JSPF/TrackReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/JSPF/TrackReader.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.Common.Json.Converters;
+using MetaBrainz.ListenBrainz.Interfaces.JSPF;
+using MetaBrainz.ListenBrainz.Objects.JSPF;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers.JSPF;
+
+internal class TrackReader : ObjectReader<Track> {
+
+  public static readonly TrackReader Instance = new();
+
+  protected override Track ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    string? album = null;
+    string? annotation = null;
+    string? creator = null;
+    uint? duration = null;
+    IReadOnlyDictionary<Uri, IReadOnlyList<object?>?>? extensions = null;
+    IReadOnlyList<Uri>? identifiers = null;
+    Uri? image = null;
+    Uri? info = null;
+    IReadOnlyList<ILink>? links = null;
+    IReadOnlyList<Uri>? locations = null;
+    IReadOnlyList<IMeta>? meta = null;
+    string? title = null;
+    uint? trackNumber = null;
+    Dictionary<string, object?>? rest = null;
+    while (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      try {
+        reader.Read();
+        switch (prop) {
+          case "album":
+            album = reader.GetString();
+            break;
+          case "annotation":
+            annotation = reader.GetString();
+            break;
+          case "creator":
+            creator = reader.GetString();
+            break;
+          case "duration":
+            duration = reader.GetUInt32();
+            break;
+          case "image":
+            image = reader.GetOptionalUri();
+            break;
+          case "info":
+            info = reader.GetOptionalUri();
+            break;
+          case "extension":
+            extensions = reader.ReadExtensions(options);
+            break;
+          case "identifier":
+            if (reader.TokenType == JsonTokenType.String) {
+              // LB-1836: this is a violation of the JSPF spec, but it's what ListenBrainz currently does.
+              identifiers = [ reader.GetUri() ];
+            }
+            else {
+              identifiers = reader.ReadList<Uri>(options);
+            }
+            break;
+          case "link":
+            links = reader.ReadList(LinkReader.Instance, options);
+            break;
+          case "location":
+            locations = reader.ReadList<Uri>(options);
+            break;
+          case "meta":
+            meta = reader.ReadList(MetaReader.Instance, options);
+            break;
+          case "title":
+            title = reader.GetString();
+            break;
+          case "trackNum":
+            trackNumber = reader.GetUInt32();
+            break;
+          default:
+            rest ??= [ ];
+            rest[prop] = reader.GetOptionalObject(options);
+            break;
+        }
+      }
+      catch (Exception e) {
+        throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+      }
+      reader.Read();
+    }
+    return new Track {
+      Album = album,
+      Annotation = annotation,
+      Creator = creator,
+      Duration = duration is null ? null : TimeSpan.FromMilliseconds(duration.Value),
+      Extensions = extensions,
+      Identifiers = identifiers,
+      Image = image,
+      Info = info,
+      Links = links,
+      Locations = locations,
+      Metadata = meta,
+      Title = title,
+      TrackNumber = trackNumber,
+      UnhandledProperties = rest,
+    };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Readers/LatestImportReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/LatestImportReader.cs
@@ -28,7 +28,7 @@ internal sealed class LatestImportReader : ObjectReader<LatestImport> {
             user = reader.GetString();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/ListenCountReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ListenCountReader.cs
@@ -23,7 +23,7 @@ internal sealed class ListenCountReader : PayloadReader<ListenCount> {
             count = reader.GetInt64();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/ListenReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ListenReader.cs
@@ -41,7 +41,7 @@ internal class ListenReader : ObjectReader<Listen> {
             user = reader.GetString();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/ListenTimeRangeReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ListenTimeRangeReader.cs
@@ -40,7 +40,7 @@ internal sealed class ListenTimeRangeReader : ObjectReader<ListenTimeRange> {
             break;
           }
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/ListeningActivityReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ListeningActivityReader.cs
@@ -52,7 +52,7 @@ internal sealed class ListeningActivityReader : PayloadReader<ListeningActivity>
             user = reader.GetString();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/MissingField.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/MissingField.cs
@@ -1,0 +1,5 @@
+﻿using System.Text.Json;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers;
+
+internal sealed class MissingField(string field) : JsonException($"Expected '{field}' field not found or null.");

--- a/MetaBrainz.ListenBrainz/Json/Readers/MusicBrainzIdMappingsReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/MusicBrainzIdMappingsReader.cs
@@ -49,7 +49,7 @@ internal sealed class MusicBrainzIdMappingsReader : ObjectReader<MusicBrainzIdMa
             release= reader.GetOptionalGuid();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/NewReleaseReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/NewReleaseReader.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.Common.Json.Converters;
+using MetaBrainz.ListenBrainz.Interfaces;
+using MetaBrainz.ListenBrainz.Objects;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers;
+
+internal class NewReleaseReader : ObjectReader<NewRelease> {
+
+  public static readonly NewReleaseReader Instance = new();
+
+
+  protected override NewRelease ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    string? artist = null;
+    long? caaId = null;
+    Guid? caaRelease = null;
+    IReadOnlyList<Guid>? creditIds = null;
+    IReadOnlyList<string>? creditNames = null;
+    IReadOnlyList<IArtistCredit>? credits = null;
+    string? firstReleaseDate = null;
+    Guid? releaseGroupId = null;
+    Guid? releaseId = null;
+    string? title = null;
+    string? type = null;
+    Dictionary<string, object?>? rest = null;
+    while (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      try {
+        reader.Read();
+        switch (prop) {
+          case "artist_credit_mbids":
+            creditIds = reader.ReadList<Guid>(options);
+            break;
+          case "artist_credit_name":
+            artist = reader.GetString();
+            break;
+          case "artist_credit_names":
+            creditNames = reader.ReadList<string>(options);
+            break;
+          case "artists":
+            credits = reader.ReadList(ArtistCreditReader.Instance, options);
+            break;
+          case "caa_id":
+            caaId = reader.GetOptionalInt64();
+            break;
+          case "caa_release_mbid":
+            caaRelease = reader.GetOptionalGuid();
+            break;
+          case "first_release_date":
+            firstReleaseDate = reader.GetString();
+            break;
+          case "release_mbid":
+            releaseId = reader.GetOptionalGuid();
+            break;
+          case "release_group_mbid":
+            releaseGroupId = reader.GetOptionalGuid();
+            break;
+          case "title":
+            title = reader.GetString();
+            break;
+          case "type":
+            type = reader.GetString();
+            break;
+          default:
+            rest ??= new Dictionary<string, object?>();
+            rest[prop] = reader.GetOptionalObject(options);
+            break;
+        }
+      }
+      catch (Exception e) {
+        throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+      }
+      reader.Read();
+    }
+    return new NewRelease {
+      CoverArtId = caaId,
+      CoverArtReleaseId = caaRelease,
+      CreditedArtist = artist,
+      CreditedArtistIds = creditIds,
+      CreditedArtistNames = creditNames,
+      CreditedArtists = credits,
+      FirstReleaseDate = firstReleaseDate,
+      ReleaseGroupId = releaseGroupId,
+      ReleaseId = releaseId,
+      Title = title ?? throw new JsonException("Expected release title not found or null."),
+      Type = type,
+      UnhandledProperties = rest,
+    };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Readers/NewReleaseReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/NewReleaseReader.cs
@@ -67,7 +67,7 @@ internal class NewReleaseReader : ObjectReader<NewRelease> {
             type = reader.GetString();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/PlayingNowReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/PlayingNowReader.cs
@@ -51,7 +51,7 @@ internal sealed class PlayingNowReader : PayloadReader<PlayingNow> {
             user = reader.GetString();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/PlayingTrackReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/PlayingTrackReader.cs
@@ -25,7 +25,7 @@ internal sealed class PlayingTrackReader : ObjectReader<PlayingTrack> {
             track = reader.GetObject(TrackInfoReader.Instance, options);
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/RecordingInfoReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/RecordingInfoReader.cs
@@ -73,7 +73,7 @@ internal class RecordingInfoReader : ObjectReader<RecordingInfo> {
             name = reader.GetString();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/RecordingStatisticsReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/RecordingStatisticsReader.cs
@@ -64,7 +64,7 @@ internal sealed class RecordingStatisticsReader : PayloadReader<RecordingStatist
             user = reader.GetString();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/ReleaseGroupInfoReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ReleaseGroupInfoReader.cs
@@ -53,7 +53,7 @@ internal class ReleaseGroupInfoReader : ObjectReader<ReleaseGroupInfo> {
             name = reader.GetString();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/ReleaseGroupInfoReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ReleaseGroupInfoReader.cs
@@ -68,7 +68,7 @@ internal class ReleaseGroupInfoReader : ObjectReader<ReleaseGroupInfo> {
       ArtistName = artistName,
       Credits = credits,
       CoverArtId = caaId,
-      CoverArtReleaseGroupId = caaRelease,
+      CoverArtReleaseId = caaRelease,
       Id = mbid,
       ListenCount = listenCount ?? throw new JsonException("Expected listen count not found or null."),
       Name = name ?? throw new JsonException("Expected release group name not found or null."),

--- a/MetaBrainz.ListenBrainz/Json/Readers/ReleaseGroupListenersReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ReleaseGroupListenersReader.cs
@@ -80,7 +80,7 @@ internal sealed class ReleaseGroupListenersReader : PayloadReader<ReleaseGroupLi
             totalListeners = reader.GetInt32();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/ReleaseGroupListenersReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ReleaseGroupListenersReader.cs
@@ -94,7 +94,7 @@ internal sealed class ReleaseGroupListenersReader : PayloadReader<ReleaseGroupLi
       ArtistIds = artistMbids,
       ArtistName = artistName,
       CoverArtId = caaId,
-      CoverArtReleaseGroupId = caaRelease,
+      CoverArtReleaseId = caaRelease,
       Id = mbid ?? throw new JsonException("Expected release group MBID not found or null."),
       LastUpdated = lastUpdated ?? throw new JsonException("Expected last-updated timestamp not found or null."),
       Name = name ?? throw new JsonException("Expected release group name not found or null."),

--- a/MetaBrainz.ListenBrainz/Json/Readers/ReleaseGroupStatisticsReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ReleaseGroupStatisticsReader.cs
@@ -64,7 +64,7 @@ internal sealed class ReleaseGroupStatisticsReader : PayloadReader<ReleaseGroupS
             user = reader.GetString();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/ReleaseInfoReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ReleaseInfoReader.cs
@@ -61,7 +61,7 @@ internal class ReleaseInfoReader : ObjectReader<ReleaseInfo> {
             name = reader.GetString();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/ReleaseStatisticsReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ReleaseStatisticsReader.cs
@@ -64,7 +64,7 @@ internal sealed class ReleaseStatisticsReader : PayloadReader<ReleaseStatistics>
             user = reader.GetString();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/TokenValidationResultReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/TokenValidationResultReader.cs
@@ -37,7 +37,7 @@ internal sealed class TokenValidationResultReader : ObjectReader<TokenValidation
             valid = reader.GetBoolean();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/TopArtistReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/TopArtistReader.cs
@@ -36,7 +36,7 @@ internal class TopArtistReader : ObjectReader<TopArtist> {
             listenCount = reader.GetInt32();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }
@@ -57,7 +57,7 @@ internal class TopArtistReader : ObjectReader<TopArtist> {
     }
     // if we did not use a non-empty artist_mbids to populate artist_mbid, retain it as an unhandled property
     if (mbids is not null) {
-      rest ??= new Dictionary<string, object?>();
+      rest ??= [ ];
       rest["artist_mbids"] = mbids;
     }
     return new TopArtist {

--- a/MetaBrainz.ListenBrainz/Json/Readers/TopGenreReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/TopGenreReader.cs
@@ -32,7 +32,7 @@ internal sealed class TopGenreReader : ObjectReader<TopGenre> {
             percentage = reader.GetDecimal();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/TopGenreReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/TopGenreReader.cs
@@ -8,20 +8,28 @@ using MetaBrainz.ListenBrainz.Objects;
 
 namespace MetaBrainz.ListenBrainz.Json.Readers;
 
-internal class ArtistActivityReader : ObjectReader<ArtistActivity> {
+internal sealed class TopGenreReader : ObjectReader<TopGenre> {
 
-  public static readonly ArtistActivityReader Instance = new();
+  public static readonly TopGenreReader Instance = new();
 
-  protected override ArtistActivity ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
-    IReadOnlyList<ArtistActivityInfo>? artists = null;
+  protected override TopGenre ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    int? count = null;
+    string? genre = null;
+    decimal? percentage = null;
     Dictionary<string, object?>? rest = null;
     while (reader.TokenType == JsonTokenType.PropertyName) {
       var prop = reader.GetPropertyName();
       try {
         reader.Read();
         switch (prop) {
-          case "result":
-            artists = reader.ReadList(ArtistActivityInfoReader.Instance, options);
+          case "genre":
+            genre = reader.GetString();
+            break;
+          case "genre_count":
+            count = reader.GetInt32();
+            break;
+          case "genre_count_percent":
+            percentage = reader.GetDecimal();
             break;
           default:
             rest ??= new Dictionary<string, object?>();
@@ -34,8 +42,10 @@ internal class ArtistActivityReader : ObjectReader<ArtistActivity> {
       }
       reader.Read();
     }
-    return new ArtistActivity {
-      Artists = artists ?? throw new JsonException("Expected result set not found or null."),
+    return new TopGenre {
+      Genre = genre ?? throw new MissingField("genre"),
+      ListenCount = count ?? throw new MissingField("genre_count"),
+      Percentage = percentage ?? throw new MissingField("genre_count_percent"),
       UnhandledProperties = rest,
     };
   }

--- a/MetaBrainz.ListenBrainz/Json/Readers/TopListenerReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/TopListenerReader.cs
@@ -28,7 +28,7 @@ internal class TopListenerReader : ObjectReader<TopListener> {
             listenCount = reader.GetInt32();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/TopRecordingReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/TopRecordingReader.cs
@@ -9,11 +9,11 @@ using MetaBrainz.ListenBrainz.Objects;
 
 namespace MetaBrainz.ListenBrainz.Json.Readers;
 
-internal class ReleaseGroupInfoReader : ObjectReader<ReleaseGroupInfo> {
+internal class TopRecordingReader : ObjectReader<TopRecording> {
 
-  public static readonly ReleaseGroupInfoReader Instance = new();
+  public static readonly TopRecordingReader Instance = new();
 
-  protected override ReleaseGroupInfo ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+  protected override TopRecording ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
     IReadOnlyList<Guid>? artistMbids = null;
     string? artistName = null;
     long? caaId = null;
@@ -22,6 +22,8 @@ internal class ReleaseGroupInfoReader : ObjectReader<ReleaseGroupInfo> {
     int? listenCount = null;
     Guid? mbid = null;
     string? name = null;
+    Guid? releaseId = null;
+    string? releaseName = null;
     Dictionary<string, object?>? rest = null;
     while (reader.TokenType == JsonTokenType.PropertyName) {
       var prop = reader.GetPropertyName();
@@ -46,10 +48,16 @@ internal class ReleaseGroupInfoReader : ObjectReader<ReleaseGroupInfo> {
           case "listen_count":
             listenCount = reader.GetInt32();
             break;
-          case "release_group_mbid":
+          case "recording_mbid":
             mbid = reader.GetOptionalGuid();
             break;
-          case "release_group_name":
+          case "release_mbid":
+            releaseId = reader.GetOptionalGuid();
+            break;
+          case "release_name":
+            releaseName = reader.GetString();
+            break;
+          case "track_name":
             name = reader.GetString();
             break;
           default:
@@ -63,7 +71,7 @@ internal class ReleaseGroupInfoReader : ObjectReader<ReleaseGroupInfo> {
       }
       reader.Read();
     }
-    return new ReleaseGroupInfo {
+    return new TopRecording {
       ArtistIds = artistMbids,
       ArtistName = artistName,
       Credits = credits,
@@ -72,6 +80,8 @@ internal class ReleaseGroupInfoReader : ObjectReader<ReleaseGroupInfo> {
       Id = mbid,
       ListenCount = listenCount ?? throw new JsonException("Expected listen count not found or null."),
       Name = name ?? throw new JsonException("Expected release group name not found or null."),
+      ReleaseId = releaseId,
+      ReleaseName = releaseName,
       UnhandledProperties = rest,
     };
   }

--- a/MetaBrainz.ListenBrainz/Json/Readers/TopRecordingReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/TopRecordingReader.cs
@@ -61,7 +61,7 @@ internal class TopRecordingReader : ObjectReader<TopRecording> {
             name = reader.GetString();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/TopRecordingReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/TopRecordingReader.cs
@@ -75,7 +75,7 @@ internal class TopRecordingReader : ObjectReader<TopRecording> {
       ArtistIds = artistMbids,
       ArtistName = artistName,
       CoverArtId = caaId,
-      CoverArtReleaseGroupId = caaRelease,
+      CoverArtReleaseId = caaRelease,
       Credits = credits,
       Id = mbid,
       ListenCount = listenCount ?? throw new JsonException("Expected listen count not found or null."),

--- a/MetaBrainz.ListenBrainz/Json/Readers/TopRecordingReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/TopRecordingReader.cs
@@ -74,9 +74,9 @@ internal class TopRecordingReader : ObjectReader<TopRecording> {
     return new TopRecording {
       ArtistIds = artistMbids,
       ArtistName = artistName,
-      Credits = credits,
       CoverArtId = caaId,
       CoverArtReleaseGroupId = caaRelease,
+      Credits = credits,
       Id = mbid,
       ListenCount = listenCount ?? throw new JsonException("Expected listen count not found or null."),
       Name = name ?? throw new JsonException("Expected release group name not found or null."),

--- a/MetaBrainz.ListenBrainz/Json/Readers/TopReleaseReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/TopReleaseReader.cs
@@ -9,16 +9,15 @@ using MetaBrainz.ListenBrainz.Objects;
 
 namespace MetaBrainz.ListenBrainz.Json.Readers;
 
-internal class ReleaseGroupInfoReader : ObjectReader<ReleaseGroupInfo> {
+internal class TopReleaseReader : ObjectReader<TopRelease> {
 
-  public static readonly ReleaseGroupInfoReader Instance = new();
+  public static readonly TopReleaseReader Instance = new();
 
-  protected override ReleaseGroupInfo ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+  protected override TopRelease ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
     IReadOnlyList<Guid>? artistMbids = null;
     string? artistName = null;
     long? caaId = null;
     Guid? caaRelease = null;
-    IReadOnlyList<IArtistCredit>? credits = null;
     int? listenCount = null;
     Guid? mbid = null;
     string? name = null;
@@ -34,9 +33,6 @@ internal class ReleaseGroupInfoReader : ObjectReader<ReleaseGroupInfo> {
           case "artist_name":
             artistName = reader.GetString();
             break;
-          case "artists":
-            credits = reader.ReadList(ArtistCreditReader.Instance, options);
-            break;
           case "caa_id":
             caaId = reader.GetOptionalInt64();
             break;
@@ -46,10 +42,10 @@ internal class ReleaseGroupInfoReader : ObjectReader<ReleaseGroupInfo> {
           case "listen_count":
             listenCount = reader.GetInt32();
             break;
-          case "release_group_mbid":
+          case "release_mbid":
             mbid = reader.GetOptionalGuid();
             break;
-          case "release_group_name":
+          case "release_name":
             name = reader.GetString();
             break;
           default:
@@ -63,15 +59,14 @@ internal class ReleaseGroupInfoReader : ObjectReader<ReleaseGroupInfo> {
       }
       reader.Read();
     }
-    return new ReleaseGroupInfo {
+    return new TopRelease {
       ArtistIds = artistMbids,
       ArtistName = artistName,
-      Credits = credits,
       CoverArtId = caaId,
       CoverArtReleaseGroupId = caaRelease,
       Id = mbid,
       ListenCount = listenCount ?? throw new JsonException("Expected listen count not found or null."),
-      Name = name ?? throw new JsonException("Expected release group name not found or null."),
+      Name = name ?? throw new JsonException("Expected release name not found or null."),
       UnhandledProperties = rest,
     };
   }

--- a/MetaBrainz.ListenBrainz/Json/Readers/TopReleaseReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/TopReleaseReader.cs
@@ -63,7 +63,7 @@ internal class TopReleaseReader : ObjectReader<TopRelease> {
       ArtistIds = artistMbids,
       ArtistName = artistName,
       CoverArtId = caaId,
-      CoverArtReleaseGroupId = caaRelease,
+      CoverArtReleaseId = caaRelease,
       Id = mbid,
       ListenCount = listenCount ?? throw new JsonException("Expected listen count not found or null."),
       Name = name ?? throw new JsonException("Expected release name not found or null."),

--- a/MetaBrainz.ListenBrainz/Json/Readers/TopReleaseReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/TopReleaseReader.cs
@@ -49,7 +49,7 @@ internal class TopReleaseReader : ObjectReader<TopRelease> {
             name = reader.GetString();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/TrackInfoReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/TrackInfoReader.cs
@@ -41,7 +41,7 @@ internal sealed class TrackInfoReader : ObjectReader<TrackInfo> {
             name = reader.GetString();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/UserDailyActivityReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/UserDailyActivityReader.cs
@@ -52,7 +52,7 @@ internal sealed class UserDailyActivityReader : PayloadReader<UserDailyActivity>
             user = reader.GetString();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/YearInMusicDataReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/YearInMusicDataReader.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.Common.Json.Converters;
+using MetaBrainz.ListenBrainz.Interfaces;
+using MetaBrainz.ListenBrainz.Objects;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers;
+
+internal sealed class YearInMusicDataReader : ObjectReader<YearInMusicData> {
+
+  public static readonly YearInMusicDataReader Instance = new();
+
+  protected override YearInMusicData ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    int? artistCount = null;
+    IReadOnlyList<IArtistCountryInfo>? artistMap = null;
+    string? dayOfWeek = null;
+    IReadOnlyDictionary<string, Uri>? discoveriesCoverArt = null;
+    object? discoveriesPlaylist = null;
+    int? listenCount = null;
+    double? listenedMinutes = null;
+    IReadOnlyList<IListenTimeRange>? listensPerDay = null;
+    IReadOnlyDictionary<string, Uri>? missedRecordingsCoverArt = null;
+    object? missedRecordingsPlaylist = null;
+    IReadOnlyDictionary<string, int>? mostListenedYear = null;
+    string? mostProminentColor = null;
+    int? newArtistsDiscovered = null;
+    IReadOnlyDictionary<string, Uri>? newRecordingsCoverArt = null;
+    object? newRecordingsPlaylist = null;
+    IReadOnlyList<INewRelease>? newReleasesOfTopArtists = null;
+    int? recordingCount = null;
+    IReadOnlyDictionary<string, Uri>? recordingsCoverArt = null;
+    object? recordingsPlaylist = null;
+    int? releaseCount = null;
+    int? releaseGroupCount = null;
+    IReadOnlyDictionary<string, decimal>? similarUsers = null;
+    IReadOnlyList<ITopArtist>? topArtists = null;
+    IReadOnlyList<ITopGenre>? topGenres = null;
+    IReadOnlyList<ITopRecording>? topRecordings = null;
+    IReadOnlyList<IReleaseGroupInfo>? topReleaseGroups = null;
+    IReadOnlyList<ITopRelease>? topReleases = null;
+    IReadOnlyDictionary<string, Uri>? topReleasesCoverArt = null;
+    Dictionary<string, object?>? rest = null;
+    while (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      try {
+        reader.Read();
+        switch (prop) {
+          case "artist_map":
+            artistMap = reader.ReadList(ArtistCountryInfoReader.Instance, options);
+            break;
+          case "day_of_week":
+            dayOfWeek = reader.GetString();
+            break;
+          case "listens_per_day":
+            listensPerDay = reader.ReadList(ListenTimeRangeReader.Instance, options);
+            break;
+          case "most_listened_year":
+            mostListenedYear = reader.ReadDictionary<int>(options);
+            break;
+          case "most_prominent_color":
+            mostProminentColor = reader.GetString();
+            break;
+          case "new_releases_of_top_artists":
+            newReleasesOfTopArtists = reader.ReadList(NewReleaseReader.Instance, options);
+            break;
+          case "playlist-top-discoveries-for-year":
+            discoveriesPlaylist = reader.GetOptionalObject(options);
+            break;
+          case "playlist-top-discoveries-for-year-coverart":
+            discoveriesCoverArt = reader.ReadDictionary<Uri>(options);
+            break;
+          case "playlist-top-missed-recordings-for-year":
+            missedRecordingsPlaylist = reader.GetOptionalObject(options);
+            break;
+          case "playlist-top-missed-recordings-for-year-coverart":
+            missedRecordingsCoverArt = reader.ReadDictionary<Uri>(options);
+            break;
+          case "playlist-top-new-recordings-for-year":
+            newRecordingsPlaylist = reader.GetOptionalObject(options);
+            break;
+          case "playlist-top-new-recordings-for-year-coverart":
+            newRecordingsCoverArt = reader.ReadDictionary<Uri>(options);
+            break;
+          case "playlist-top-recordings-for-year":
+            recordingsPlaylist = reader.GetOptionalObject(options);
+            break;
+          case "playlist-top-recordings-for-year-coverart":
+            recordingsCoverArt = reader.ReadDictionary<Uri>(options);
+            break;
+          case "similar_users":
+            similarUsers = reader.ReadDictionary<decimal>(options);
+            break;
+          case "top_artists":
+            topArtists = reader.ReadList(TopArtistReader.Instance, options);
+            break;
+          case "top_genres":
+            topGenres = reader.ReadList(TopGenreReader.Instance, options);
+            break;
+          case "top_recordings":
+            topRecordings = reader.ReadList(TopRecordingReader.Instance, options);
+            break;
+          case "top_release_groups":
+            topReleaseGroups = reader.ReadList(ReleaseGroupInfoReader.Instance, options);
+            break;
+          case "top_releases":
+            topReleases = reader.ReadList(TopReleaseReader.Instance, options);
+            break;
+          case "top_releases_coverart":
+            topReleasesCoverArt = reader.ReadDictionary<Uri>(options);
+            break;
+          case "total_artists_count":
+            artistCount = reader.GetInt32();
+            break;
+          case "total_listen_count":
+            listenCount = reader.GetInt32();
+            break;
+          case "total_listening_time":
+            listenedMinutes = reader.GetDouble();
+            break;
+          case "total_new_artists_discovered":
+            newArtistsDiscovered = reader.GetInt32();
+            break;
+          case "total_recordings_count":
+            recordingCount = reader.GetInt32();
+            break;
+          case "total_releases_count":
+            releaseCount = reader.GetInt32();
+            break;
+          case "total_release_groups_count":
+            releaseGroupCount = reader.GetInt32();
+            break;
+          case "yim_artist_map":
+            // this is identical to artist_map, and typically huge, so just skip it
+            reader.Skip();
+            break;
+          default:
+            rest ??= new Dictionary<string, object?>();
+            rest[prop] = reader.GetOptionalObject(options);
+            break;
+        }
+      }
+      catch (Exception e) {
+        throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+      }
+      reader.Read();
+    }
+    TimeSpan? listeningTime = listenedMinutes is null ? null : TimeSpan.FromSeconds(listenedMinutes.Value);
+    return new YearInMusicData {
+      ArtistCount = artistCount,
+      ArtistMap = artistMap,
+      DayOfWeek = dayOfWeek,
+      ListenCount = listenCount,
+      ListeningTime = listeningTime,
+      ListensPerDay = listensPerDay,
+      MostListenedYear = mostListenedYear,
+      MostProminentColor = mostProminentColor,
+      NewArtistsDiscovered = newArtistsDiscovered,
+      NewReleasesOfTopArtists = newReleasesOfTopArtists,
+      RecordingCount = recordingCount,
+      ReleaseCount = releaseCount,
+      ReleaseGroupCount = releaseGroupCount,
+      SimilarUsers = similarUsers,
+      TopArtists = topArtists,
+      TopGenres = topGenres,
+      TopDiscoveriesPlaylist = discoveriesPlaylist,
+      TopDiscoveriesPlaylistCoverArt = discoveriesCoverArt,
+      TopMissedRecordingsPlaylist = missedRecordingsPlaylist,
+      TopMissedRecordingsPlaylistCoverArt = missedRecordingsCoverArt,
+      TopNewRecordingsPlaylist = newRecordingsPlaylist,
+      TopNewRecordingsPlaylistCoverArt = newRecordingsCoverArt,
+      TopRecordings = topRecordings,
+      TopRecordingsPlaylist = recordingsPlaylist,
+      TopRecordingsPlaylistCoverArt = recordingsCoverArt,
+      TopReleaseGroups = topReleaseGroups,
+      TopReleases = topReleases,
+      TopReleasesCoverArt = topReleasesCoverArt,
+      UnhandledProperties = rest,
+    };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Readers/YearInMusicDataReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/YearInMusicDataReader.cs
@@ -5,6 +5,8 @@ using System.Text.Json;
 using MetaBrainz.Common.Json;
 using MetaBrainz.Common.Json.Converters;
 using MetaBrainz.ListenBrainz.Interfaces;
+using MetaBrainz.ListenBrainz.Interfaces.JSPF;
+using MetaBrainz.ListenBrainz.Json.Readers.JSPF;
 using MetaBrainz.ListenBrainz.Objects;
 
 namespace MetaBrainz.ListenBrainz.Json.Readers;
@@ -18,21 +20,21 @@ internal sealed class YearInMusicDataReader : ObjectReader<YearInMusicData> {
     IReadOnlyList<IArtistCountryInfo>? artistMap = null;
     string? dayOfWeek = null;
     IReadOnlyDictionary<string, Uri>? discoveriesCoverArt = null;
-    object? discoveriesPlaylist = null;
+    IPlaylist? discoveriesPlaylist = null;
     int? listenCount = null;
     double? listenedMinutes = null;
     IReadOnlyList<IListenTimeRange>? listensPerDay = null;
     IReadOnlyDictionary<string, Uri>? missedRecordingsCoverArt = null;
-    object? missedRecordingsPlaylist = null;
+    IPlaylist? missedRecordingsPlaylist = null;
     IReadOnlyDictionary<string, int>? mostListenedYear = null;
     string? mostProminentColor = null;
     int? newArtistsDiscovered = null;
     IReadOnlyDictionary<string, Uri>? newRecordingsCoverArt = null;
-    object? newRecordingsPlaylist = null;
+    IPlaylist? newRecordingsPlaylist = null;
     IReadOnlyList<INewRelease>? newReleasesOfTopArtists = null;
     int? recordingCount = null;
     IReadOnlyDictionary<string, Uri>? recordingsCoverArt = null;
-    object? recordingsPlaylist = null;
+    IPlaylist? recordingsPlaylist = null;
     int? releaseCount = null;
     int? releaseGroupCount = null;
     IReadOnlyDictionary<string, decimal>? similarUsers = null;
@@ -67,25 +69,25 @@ internal sealed class YearInMusicDataReader : ObjectReader<YearInMusicData> {
             newReleasesOfTopArtists = reader.ReadList(NewReleaseReader.Instance, options);
             break;
           case "playlist-top-discoveries-for-year":
-            discoveriesPlaylist = reader.GetOptionalObject(options);
+            discoveriesPlaylist = reader.GetOptionalObject(PlaylistReader.Instance, options);
             break;
           case "playlist-top-discoveries-for-year-coverart":
             discoveriesCoverArt = reader.ReadDictionary<Uri>(options);
             break;
           case "playlist-top-missed-recordings-for-year":
-            missedRecordingsPlaylist = reader.GetOptionalObject(options);
+            missedRecordingsPlaylist = reader.GetOptionalObject(PlaylistReader.Instance, options);
             break;
           case "playlist-top-missed-recordings-for-year-coverart":
             missedRecordingsCoverArt = reader.ReadDictionary<Uri>(options);
             break;
           case "playlist-top-new-recordings-for-year":
-            newRecordingsPlaylist = reader.GetOptionalObject(options);
+            newRecordingsPlaylist = reader.GetOptionalObject(PlaylistReader.Instance, options);
             break;
           case "playlist-top-new-recordings-for-year-coverart":
             newRecordingsCoverArt = reader.ReadDictionary<Uri>(options);
             break;
           case "playlist-top-recordings-for-year":
-            recordingsPlaylist = reader.GetOptionalObject(options);
+            recordingsPlaylist = reader.GetOptionalObject(PlaylistReader.Instance, options);
             break;
           case "playlist-top-recordings-for-year-coverart":
             recordingsCoverArt = reader.ReadDictionary<Uri>(options);

--- a/MetaBrainz.ListenBrainz/Json/Readers/YearInMusicDataReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/YearInMusicDataReader.cs
@@ -139,7 +139,7 @@ internal sealed class YearInMusicDataReader : ObjectReader<YearInMusicData> {
             reader.Skip();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/YearInMusicReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/YearInMusicReader.cs
@@ -28,7 +28,7 @@ internal class YearInMusicReader : PayloadReader<YearInMusic> {
             user = reader.GetString();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/Json/Readers/YearlyActivityReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/YearlyActivityReader.cs
@@ -28,7 +28,7 @@ internal sealed class YearlyActivityReader : ObjectReader<YearlyActivity> {
             year = reader.GetInt32();
             break;
           default:
-            rest ??= new Dictionary<string, object?>();
+            rest ??= [ ];
             rest[prop] = reader.GetOptionalObject(options);
             break;
         }

--- a/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.Statistics.cs
+++ b/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.Statistics.cs
@@ -36,246 +36,6 @@ public sealed partial class ListenBrainz {
     return options;
   }
 
-  #region /1/stats/sitewide/artist-activity
-
-  /// <summary>Gets listening statistics for the top artists (and their albums) across all of ListenBrainz.</summary>
-  /// <param name="range">The range of data to include in the statistics.</param>
-  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested information, if available.</returns>
-  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
-  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
-  public Task<IArtistActivity?> GetArtistActivityAsync(StatisticsRange? range = null,
-                                                       CancellationToken cancellationToken = default) {
-    var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
-    return this.GetOptionalAsync<IArtistActivity, ArtistActivity>("stats/sitewide/artist-activity", options, cancellationToken);
-  }
-
-  #endregion
-
-  #region /1/stats/user/xxx/artist-activity
-
-  /// <summary>Gets listening statistics for a user's top artists (and their albums).</summary>
-  /// <param name="user">The user for whom the information is requested.</param>
-  /// <param name="range">The range of data to include in the statistics.</param>
-  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested information, if available.</returns>
-  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
-  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
-  public Task<IArtistActivity?> GetArtistActivityAsync(string user, StatisticsRange? range = null,
-                                                       CancellationToken cancellationToken = default) {
-    var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
-    return this.GetOptionalAsync<IArtistActivity, ArtistActivity>($"stats/user/{user}/artist-activity", options, cancellationToken);
-  }
-
-  #endregion
-
-  #region /1/stats/sitewide/artist-evolution-activity
-
-  /// <summary>Gets listening statistics for artists over time across all of ListenBrainz.</summary>
-  /// <param name="range">
-  /// The range of data to include in the statistics. This impacts the time units used by the returned information.
-  /// </param>
-  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested information, if available.</returns>
-  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
-  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
-  public Task<IArtistEvolutionActivity?> GetArtistEvolutionActivityAsync(StatisticsRange? range = null,
-                                                                         CancellationToken cancellationToken = default) {
-    const string address = "stats/sitewide/artist-evolution-activity";
-    var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
-    return this.GetOptionalAsync<IArtistEvolutionActivity, ArtistEvolutionActivity>(address, options, cancellationToken);
-  }
-
-  #endregion
-
-  #region /1/stats/user/xxx/artist-evolution-activity
-
-  /// <summary>Gets a user's listening statistics for artists over time.</summary>
-  /// <param name="user">The user for whom the information is requested.</param>
-  /// <param name="range">
-  /// The range of data to include in the statistics. This impacts the time units used by the returned information.
-  /// </param>
-  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested information, if available.</returns>
-  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
-  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
-  public Task<IArtistEvolutionActivity?> GetArtistEvolutionActivityAsync(string user, StatisticsRange? range = null,
-                                                                         CancellationToken cancellationToken = default) {
-    var address = $"stats/user/{user}/artist-evolution-activity";
-    var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
-    return this.GetOptionalAsync<IArtistEvolutionActivity, ArtistEvolutionActivity>(address, options, cancellationToken);
-  }
-
-  #endregion
-
-  #region /1/stats/sitewide/artist-map
-
-  /// <summary>
-  /// Gets information about the number of times artists are listened to across all of ListenBrainz, grouped by their country.
-  /// </summary>
-  /// <param name="range">The range of data to include in the statistics.</param>
-  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested information, if available.</returns>
-  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
-  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
-  public Task<IArtistMap?> GetArtistMapAsync(StatisticsRange? range = null, CancellationToken cancellationToken = default) {
-    var options = ListenBrainz.OptionsForGetArtistMap(range);
-    return this.GetOptionalAsync<IArtistMap, ArtistMap>("stats/sitewide/artist-map", options, cancellationToken);
-  }
-
-  #endregion
-
-  #region /1/stats/user/xxx/artist-map
-
-  /// <summary>Gets information about the number of artists a user has listened to, grouped by their country.</summary>
-  /// <param name="user">The user for whom the information is requested.</param>
-  /// <param name="range">The range of data to include in the statistics.</param>
-  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested information, if available.</returns>
-  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
-  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
-  public Task<IArtistMap?> GetArtistMapAsync(string user, StatisticsRange? range = null,
-                                             CancellationToken cancellationToken = default) {
-    var options = ListenBrainz.OptionsForGetArtistMap(range);
-    return this.GetOptionalAsync<IArtistMap, ArtistMap>($"stats/user/{user}/artist-map", options, cancellationToken);
-  }
-
-  #endregion
-
-  #region /1/stats/sitewide/artists
-
-  /// <summary>Gets statistics about the most listened-to artists across all of ListenBrainz.</summary>
-  /// <param name="count">
-  /// The (maximum) number of entries to return. If not specified (or <see langword="null"/>), all available information will be
-  /// returned.
-  /// </param>
-  /// <param name="offset">
-  /// The offset (from the start of the results) of the statistics to return for each time range. If not specified (or specified
-  /// as zero or <see langword="null"/>), the top most listened-to artists will be returned. Note that at most 1000 artists will
-  /// be included in the statistics for each time range.
-  /// </param>
-  /// <param name="range">
-  /// The range of data to include in the statistics.<br/>
-  /// If this is unspecified or <see cref="StatisticsRange.AllTime"/>, information is returned about all years with at least one
-  /// recorded listen. Otherwise, information is returned about both the current and the previous range.
-  /// </param>
-  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested artist statistics, if available.</returns>
-  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
-  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
-  public Task<IArtistStatistics?> GetArtistStatisticsAsync(int? count = null, int? offset = null, StatisticsRange? range = null,
-                                                           CancellationToken cancellationToken = default) {
-    var options = ListenBrainz.OptionsForGetStatistics(count, offset, range);
-    return this.GetOptionalAsync<IArtistStatistics, ArtistStatistics>("stats/sitewide/artists", options, cancellationToken);
-  }
-
-  #endregion
-
-  #region /1/stats/user/xxx/artists
-
-  /// <summary>Gets statistics about a user's most listened-to artists.</summary>
-  /// <param name="user">The user for whom the statistics are requested.</param>
-  /// <param name="count">
-  /// The (maximum) number of entries to return. If not specified (or <see langword="null"/>), all available information will be
-  /// returned.
-  /// </param>
-  /// <param name="offset">
-  /// The offset (from the start of the results) of the statistics to return. If not specified (or specified as zero or
-  /// <see langword="null"/>), the top most listened-to artists will be returned.
-  /// </param>
-  /// <param name="range">The range of data to include in the statistics.</param>
-  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested artist statistics, if available.</returns>
-  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
-  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
-  public Task<IArtistStatistics?> GetArtistStatisticsAsync(string user, int? count = null, int? offset = null,
-                                                           StatisticsRange? range = null,
-                                                           CancellationToken cancellationToken = default) {
-    var options = ListenBrainz.OptionsForGetStatistics(count, offset, range);
-    return this.GetOptionalAsync<IArtistStatistics, ArtistStatistics>($"stats/user/{user}/artists", options, cancellationToken);
-  }
-
-  #endregion
-
-  #region /1/stats/user/xxx/daily-activity
-
-  /// <summary>Gets information about how a user's listens are spread across the days of the week.</summary>
-  /// <param name="user">The user for whom the information is requested.</param>
-  /// <param name="range">The range of data to include in the information.</param>
-  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested daily activity, if available.</returns>
-  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
-  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
-  public Task<IUserDailyActivity?> GetDailyActivityAsync(string user, StatisticsRange? range = null,
-                                                         CancellationToken cancellationToken = default) {
-    var address = $"stats/user/{user}/daily-activity";
-    var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
-    return this.GetOptionalAsync<IUserDailyActivity, UserDailyActivity>(address, options, cancellationToken);
-  }
-
-  #endregion
-
-  #region /1/stats/sitewide/era-activity
-
-  /// <summary>
-  /// Gets information about how many listens have been recorded across all of ListenBrainz, grouped by their release year.
-  /// </summary>
-  /// <param name="range">
-  /// The range of data to include in the information.<br/>
-  /// If this is unspecified or <see cref="StatisticsRange.AllTime"/>, information is returned about all years with at least one
-  /// recorded listen. Otherwise, information is returned about both the current and the previous range.
-  /// </param>
-  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested listening activity, if available.</returns>
-  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
-  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
-  public Task<IEraActivity?> GetEraActivityAsync(StatisticsRange? range = null, CancellationToken cancellationToken = default) {
-    var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
-    return this.GetOptionalAsync<IEraActivity, EraActivity>("stats/sitewide/era-activity", options, cancellationToken);
-  }
-
-  #endregion
-
-  #region /1/stats/user/xxx/era-activity
-
-  /// <summary>Gets information about how many listens have been recorded for a user, grouped by their release year.</summary>
-  /// <param name="user">The user for whom the information is requested.</param>
-  /// <param name="range">
-  /// The range of data to include in the information.<br/>
-  /// If this is unspecified or <see cref="StatisticsRange.AllTime"/>, information is returned about all years with at least one
-  /// recorded listen. Otherwise, information is returned about both the current and the previous range.
-  /// </param>
-  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested listening activity, if available.</returns>
-  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
-  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
-  public Task<IEraActivity?> GetEraActivityAsync(string user, StatisticsRange? range = null,
-                                                 CancellationToken cancellationToken = default) {
-    var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
-    return this.GetOptionalAsync<IEraActivity, EraActivity>($"stats/user/{user}/era-activity", options, cancellationToken);
-  }
-
-  #endregion
-
-  #region /1/stats/user/xxx/genre-activity
-
-  /// <summary>
-  /// Gets information about how many listens have been recorded for a user, grouped by the genre and the hour of the day.
-  /// </summary>
-  /// <param name="user">The user for whom the information is requested.</param>
-  /// <param name="range">The range of data to include in the information.</param>
-  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested listening activity, if available.</returns>
-  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
-  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
-  public Task<IGenreActivity?> GetGenreActivityAsync(string user, StatisticsRange? range = null,
-                                                 CancellationToken cancellationToken = default) {
-    var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
-    return this.GetOptionalAsync<IGenreActivity, GenreActivity>($"stats/user/{user}/genre-activity", options, cancellationToken);
-  }
-
-  #endregion
-
   #region /1/stats/artist/xxx/listeners
 
   /// <summary>Gets information about the top listeners for a particular artist.</summary>
@@ -339,6 +99,108 @@ public sealed partial class ListenBrainz {
 
   #endregion
 
+  #region /1/stats/sitewide/artist-activity
+
+  /// <summary>Gets listening statistics for the top artists (and their albums) across all of ListenBrainz.</summary>
+  /// <param name="range">The range of data to include in the statistics.</param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested information, if available.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IArtistActivity?> GetArtistActivityAsync(StatisticsRange? range = null,
+                                                       CancellationToken cancellationToken = default) {
+    var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
+    return this.GetOptionalAsync<IArtistActivity, ArtistActivity>("stats/sitewide/artist-activity", options, cancellationToken);
+  }
+
+  #endregion
+
+  #region /1/stats/sitewide/artist-evolution-activity
+
+  /// <summary>Gets listening statistics for artists over time across all of ListenBrainz.</summary>
+  /// <param name="range">
+  /// The range of data to include in the statistics. This impacts the time units used by the returned information.
+  /// </param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested information, if available.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IArtistEvolutionActivity?> GetArtistEvolutionActivityAsync(StatisticsRange? range = null,
+                                                                         CancellationToken cancellationToken = default) {
+    const string address = "stats/sitewide/artist-evolution-activity";
+    var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
+    return this.GetOptionalAsync<IArtistEvolutionActivity, ArtistEvolutionActivity>(address, options, cancellationToken);
+  }
+
+  #endregion
+
+  #region /1/stats/sitewide/artist-map
+
+  /// <summary>
+  /// Gets information about the number of times artists are listened to across all of ListenBrainz, grouped by their country.
+  /// </summary>
+  /// <param name="range">The range of data to include in the statistics.</param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested information, if available.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IArtistMap?> GetArtistMapAsync(StatisticsRange? range = null, CancellationToken cancellationToken = default) {
+    var options = ListenBrainz.OptionsForGetArtistMap(range);
+    return this.GetOptionalAsync<IArtistMap, ArtistMap>("stats/sitewide/artist-map", options, cancellationToken);
+  }
+
+  #endregion
+
+  #region /1/stats/sitewide/artists
+
+  /// <summary>Gets statistics about the most listened-to artists across all of ListenBrainz.</summary>
+  /// <param name="count">
+  /// The (maximum) number of entries to return. If not specified (or <see langword="null"/>), all available information will be
+  /// returned.
+  /// </param>
+  /// <param name="offset">
+  /// The offset (from the start of the results) of the statistics to return for each time range. If not specified (or specified
+  /// as zero or <see langword="null"/>), the top most listened-to artists will be returned. Note that at most 1000 artists will
+  /// be included in the statistics for each time range.
+  /// </param>
+  /// <param name="range">
+  /// The range of data to include in the statistics.<br/>
+  /// If this is unspecified or <see cref="StatisticsRange.AllTime"/>, information is returned about all years with at least one
+  /// recorded listen. Otherwise, information is returned about both the current and the previous range.
+  /// </param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested artist statistics, if available.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IArtistStatistics?> GetArtistStatisticsAsync(int? count = null, int? offset = null, StatisticsRange? range = null,
+                                                           CancellationToken cancellationToken = default) {
+    var options = ListenBrainz.OptionsForGetStatistics(count, offset, range);
+    return this.GetOptionalAsync<IArtistStatistics, ArtistStatistics>("stats/sitewide/artists", options, cancellationToken);
+  }
+
+  #endregion
+
+  #region /1/stats/sitewide/era-activity
+
+  /// <summary>
+  /// Gets information about how many listens have been recorded across all of ListenBrainz, grouped by their release year.
+  /// </summary>
+  /// <param name="range">
+  /// The range of data to include in the information.<br/>
+  /// If this is unspecified or <see cref="StatisticsRange.AllTime"/>, information is returned about all years with at least one
+  /// recorded listen. Otherwise, information is returned about both the current and the previous range.
+  /// </param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested listening activity, if available.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IEraActivity?> GetEraActivityAsync(StatisticsRange? range = null, CancellationToken cancellationToken = default) {
+    var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
+    return this.GetOptionalAsync<IEraActivity, EraActivity>("stats/sitewide/era-activity", options, cancellationToken);
+  }
+
+  #endregion
+
   #region /1/stats/sitewide/listening-activity
 
   /// <summary>Gets information about how many listens have been submitted to ListenBrainz over a period of time.</summary>
@@ -354,28 +216,6 @@ public sealed partial class ListenBrainz {
   public Task<IListeningActivity?> GetListeningActivityAsync(StatisticsRange? range = null,
                                                              CancellationToken cancellationToken = default) {
     const string address = "stats/sitewide/listening-activity";
-    var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
-    return this.GetOptionalAsync<IListeningActivity, ListeningActivity>(address, options, cancellationToken);
-  }
-
-  #endregion
-
-  #region /1/stats/user/xxx/listening-activity
-
-  /// <summary>Gets information about how many listens a user has submitted to ListenBrainz over a period of time.</summary>
-  /// <param name="user">The user for whom the information is requested.</param>
-  /// <param name="range">
-  /// The range of data to include in the information.<br/>
-  /// If this is unspecified or <see cref="StatisticsRange.AllTime"/>, information is returned about all years with at least one
-  /// recorded listen. Otherwise, information is returned about both the current and the previous range.
-  /// </param>
-  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested listening activity, if available.</returns>
-  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
-  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
-  public Task<IListeningActivity?> GetListeningActivityAsync(string user, StatisticsRange? range = null,
-                                                             CancellationToken cancellationToken = default) {
-    var address = $"stats/user/{user}/listening-activity";
     var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
     return this.GetOptionalAsync<IListeningActivity, ListeningActivity>(address, options, cancellationToken);
   }
@@ -402,33 +242,6 @@ public sealed partial class ListenBrainz {
                                                                  StatisticsRange? range = null,
                                                                  CancellationToken cancellationToken = default) {
     const string address = "stats/sitewide/recordings";
-    var options = ListenBrainz.OptionsForGetStatistics(count, offset, range);
-    return this.GetOptionalAsync<IRecordingStatistics, RecordingStatistics>(address, options, cancellationToken);
-  }
-
-  #endregion
-
-  #region /1/stats/user/xxx/recordings
-
-  /// <summary>Gets statistics about a user's most listened-to recordings ("tracks").</summary>
-  /// <param name="user">The user for whom the statistics are requested.</param>
-  /// <param name="count">
-  /// The (maximum) number of entries to return. If not specified (or <see langword="null"/>), all available information will be
-  /// returned.
-  /// </param>
-  /// <param name="offset">
-  /// The offset (from the start of the results) of the statistics to return. If not specified (or specified as zero or
-  /// <see langword="null"/>), the top most listened-to recordings will be returned.
-  /// </param>
-  /// <param name="range">The range of data to include in the statistics.</param>
-  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested recording statistics, if available.</returns>
-  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
-  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
-  public Task<IRecordingStatistics?> GetRecordingStatisticsAsync(string user, int? count = null, int? offset = null,
-                                                                 StatisticsRange? range = null,
-                                                                 CancellationToken cancellationToken = default) {
-    var address = $"stats/user/{user}/recordings";
     var options = ListenBrainz.OptionsForGetStatistics(count, offset, range);
     return this.GetOptionalAsync<IRecordingStatistics, RecordingStatistics>(address, options, cancellationToken);
   }
@@ -463,6 +276,218 @@ public sealed partial class ListenBrainz {
 
   #endregion
 
+  #region /1/stats/sitewide/releases
+
+  /// <summary>Gets statistics about the most listened-to releases ("albums") across all of ListenBrainz.</summary>
+  /// <param name="count">
+  /// The (maximum) number of entries to return. If not specified (or <see langword="null"/>), all available information will be
+  /// returned.
+  /// </param>
+  /// <param name="offset">
+  /// The offset (from the start of the results) of the statistics to return. If not specified (or specified as zero or
+  /// <see langword="null"/>), the top most listened-to releases will be returned.
+  /// </param>
+  /// <param name="range">The range of data to include in the statistics.</param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested releases statistics, if available.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IReleaseStatistics?> GetReleaseStatisticsAsync(int? count = null, int? offset = null,
+                                                             StatisticsRange? range = null,
+                                                             CancellationToken cancellationToken = default) {
+    var options = ListenBrainz.OptionsForGetStatistics(count, offset, range);
+    return this.GetOptionalAsync<IReleaseStatistics, ReleaseStatistics>("stats/sitewide/releases", options, cancellationToken);
+  }
+
+  #endregion
+
+  #region /1/stats/user/xxx/artist-activity
+
+  /// <summary>Gets listening statistics for a user's top artists (and their albums).</summary>
+  /// <param name="user">The user for whom the information is requested.</param>
+  /// <param name="range">The range of data to include in the statistics.</param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested information, if available.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IArtistActivity?> GetArtistActivityAsync(string user, StatisticsRange? range = null,
+                                                       CancellationToken cancellationToken = default) {
+    var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
+    return this.GetOptionalAsync<IArtistActivity, ArtistActivity>($"stats/user/{user}/artist-activity", options, cancellationToken);
+  }
+
+  #endregion
+
+  #region /1/stats/user/xxx/artist-evolution-activity
+
+  /// <summary>Gets a user's listening statistics for artists over time.</summary>
+  /// <param name="user">The user for whom the information is requested.</param>
+  /// <param name="range">
+  /// The range of data to include in the statistics. This impacts the time units used by the returned information.
+  /// </param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested information, if available.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IArtistEvolutionActivity?> GetArtistEvolutionActivityAsync(string user, StatisticsRange? range = null,
+                                                                         CancellationToken cancellationToken = default) {
+    var address = $"stats/user/{user}/artist-evolution-activity";
+    var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
+    return this.GetOptionalAsync<IArtistEvolutionActivity, ArtistEvolutionActivity>(address, options, cancellationToken);
+  }
+
+  #endregion
+
+  #region /1/stats/user/xxx/artist-map
+
+  /// <summary>Gets information about the number of artists a user has listened to, grouped by their country.</summary>
+  /// <param name="user">The user for whom the information is requested.</param>
+  /// <param name="range">The range of data to include in the statistics.</param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested information, if available.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IArtistMap?> GetArtistMapAsync(string user, StatisticsRange? range = null,
+                                             CancellationToken cancellationToken = default) {
+    var options = ListenBrainz.OptionsForGetArtistMap(range);
+    return this.GetOptionalAsync<IArtistMap, ArtistMap>($"stats/user/{user}/artist-map", options, cancellationToken);
+  }
+
+  #endregion
+
+  #region /1/stats/user/xxx/artists
+
+  /// <summary>Gets statistics about a user's most listened-to artists.</summary>
+  /// <param name="user">The user for whom the statistics are requested.</param>
+  /// <param name="count">
+  /// The (maximum) number of entries to return. If not specified (or <see langword="null"/>), all available information will be
+  /// returned.
+  /// </param>
+  /// <param name="offset">
+  /// The offset (from the start of the results) of the statistics to return. If not specified (or specified as zero or
+  /// <see langword="null"/>), the top most listened-to artists will be returned.
+  /// </param>
+  /// <param name="range">The range of data to include in the statistics.</param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested artist statistics, if available.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IArtistStatistics?> GetArtistStatisticsAsync(string user, int? count = null, int? offset = null,
+                                                           StatisticsRange? range = null,
+                                                           CancellationToken cancellationToken = default) {
+    var options = ListenBrainz.OptionsForGetStatistics(count, offset, range);
+    return this.GetOptionalAsync<IArtistStatistics, ArtistStatistics>($"stats/user/{user}/artists", options, cancellationToken);
+  }
+
+  #endregion
+
+  #region /1/stats/user/xxx/daily-activity
+
+  /// <summary>Gets information about how a user's listens are spread across the days of the week.</summary>
+  /// <param name="user">The user for whom the information is requested.</param>
+  /// <param name="range">The range of data to include in the information.</param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested daily activity, if available.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IUserDailyActivity?> GetDailyActivityAsync(string user, StatisticsRange? range = null,
+                                                         CancellationToken cancellationToken = default) {
+    var address = $"stats/user/{user}/daily-activity";
+    var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
+    return this.GetOptionalAsync<IUserDailyActivity, UserDailyActivity>(address, options, cancellationToken);
+  }
+
+  #endregion
+
+  #region /1/stats/user/xxx/era-activity
+
+  /// <summary>Gets information about how many listens have been recorded for a user, grouped by their release year.</summary>
+  /// <param name="user">The user for whom the information is requested.</param>
+  /// <param name="range">
+  /// The range of data to include in the information.<br/>
+  /// If this is unspecified or <see cref="StatisticsRange.AllTime"/>, information is returned about all years with at least one
+  /// recorded listen. Otherwise, information is returned about both the current and the previous range.
+  /// </param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested listening activity, if available.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IEraActivity?> GetEraActivityAsync(string user, StatisticsRange? range = null,
+                                                 CancellationToken cancellationToken = default) {
+    var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
+    return this.GetOptionalAsync<IEraActivity, EraActivity>($"stats/user/{user}/era-activity", options, cancellationToken);
+  }
+
+  #endregion
+
+  #region /1/stats/user/xxx/genre-activity
+
+  /// <summary>
+  /// Gets information about how many listens have been recorded for a user, grouped by the genre and the hour of the day.
+  /// </summary>
+  /// <param name="user">The user for whom the information is requested.</param>
+  /// <param name="range">The range of data to include in the information.</param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested listening activity, if available.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IGenreActivity?> GetGenreActivityAsync(string user, StatisticsRange? range = null,
+                                                 CancellationToken cancellationToken = default) {
+    var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
+    return this.GetOptionalAsync<IGenreActivity, GenreActivity>($"stats/user/{user}/genre-activity", options, cancellationToken);
+  }
+
+  #endregion
+
+  #region /1/stats/user/xxx/listening-activity
+
+  /// <summary>Gets information about how many listens a user has submitted to ListenBrainz over a period of time.</summary>
+  /// <param name="user">The user for whom the information is requested.</param>
+  /// <param name="range">
+  /// The range of data to include in the information.<br/>
+  /// If this is unspecified or <see cref="StatisticsRange.AllTime"/>, information is returned about all years with at least one
+  /// recorded listen. Otherwise, information is returned about both the current and the previous range.
+  /// </param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested listening activity, if available.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IListeningActivity?> GetListeningActivityAsync(string user, StatisticsRange? range = null,
+                                                             CancellationToken cancellationToken = default) {
+    var address = $"stats/user/{user}/listening-activity";
+    var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
+    return this.GetOptionalAsync<IListeningActivity, ListeningActivity>(address, options, cancellationToken);
+  }
+
+  #endregion
+
+  #region /1/stats/user/xxx/recordings
+
+  /// <summary>Gets statistics about a user's most listened-to recordings ("tracks").</summary>
+  /// <param name="user">The user for whom the statistics are requested.</param>
+  /// <param name="count">
+  /// The (maximum) number of entries to return. If not specified (or <see langword="null"/>), all available information will be
+  /// returned.
+  /// </param>
+  /// <param name="offset">
+  /// The offset (from the start of the results) of the statistics to return. If not specified (or specified as zero or
+  /// <see langword="null"/>), the top most listened-to recordings will be returned.
+  /// </param>
+  /// <param name="range">The range of data to include in the statistics.</param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested recording statistics, if available.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IRecordingStatistics?> GetRecordingStatisticsAsync(string user, int? count = null, int? offset = null,
+                                                                 StatisticsRange? range = null,
+                                                                 CancellationToken cancellationToken = default) {
+    var address = $"stats/user/{user}/recordings";
+    var options = ListenBrainz.OptionsForGetStatistics(count, offset, range);
+    return this.GetOptionalAsync<IRecordingStatistics, RecordingStatistics>(address, options, cancellationToken);
+  }
+
+  #endregion
+
   #region /1/stats/user/xxx/release-groups
 
   /// <summary>Gets statistics about a user's most listened-to release groups (sets of all editions of an "album").</summary>
@@ -486,31 +511,6 @@ public sealed partial class ListenBrainz {
     var address = $"stats/user/{user}/release-groups";
     var options = ListenBrainz.OptionsForGetStatistics(count, offset, range);
     return this.GetOptionalAsync<IReleaseGroupStatistics, ReleaseGroupStatistics>(address, options, cancellationToken);
-  }
-
-  #endregion
-
-  #region /1/stats/sitewide/releases
-
-  /// <summary>Gets statistics about the most listened-to releases ("albums") across all of ListenBrainz.</summary>
-  /// <param name="count">
-  /// The (maximum) number of entries to return. If not specified (or <see langword="null"/>), all available information will be
-  /// returned.
-  /// </param>
-  /// <param name="offset">
-  /// The offset (from the start of the results) of the statistics to return. If not specified (or specified as zero or
-  /// <see langword="null"/>), the top most listened-to releases will be returned.
-  /// </param>
-  /// <param name="range">The range of data to include in the statistics.</param>
-  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested releases statistics, if available.</returns>
-  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
-  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
-  public Task<IReleaseStatistics?> GetReleaseStatisticsAsync(int? count = null, int? offset = null,
-                                                                 StatisticsRange? range = null,
-                                                                 CancellationToken cancellationToken = default) {
-    var options = ListenBrainz.OptionsForGetStatistics(count, offset, range);
-    return this.GetOptionalAsync<IReleaseStatistics, ReleaseStatistics>("stats/sitewide/releases", options, cancellationToken);
   }
 
   #endregion

--- a/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.Statistics.cs
+++ b/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.Statistics.cs
@@ -55,7 +55,7 @@ public sealed partial class ListenBrainz {
   /// recorded listen. Otherwise, information is returned about both the current and the previous range.
   /// </param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested listener statistics, if available.</returns>
+  /// <returns>The requested information, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IArtistListeners?> GetArtistListenersAsync(Guid mbid, int? count = null, int? offset = null,
@@ -86,7 +86,7 @@ public sealed partial class ListenBrainz {
   /// recorded listen. Otherwise, information is returned about both the current and the previous range.
   /// </param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested listener statistics, if available.</returns>
+  /// <returns>The requested information, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IReleaseGroupListeners?> GetReleaseGroupListenersAsync(Guid mbid, int? count = null, int? offset = null,
@@ -169,7 +169,7 @@ public sealed partial class ListenBrainz {
   /// recorded listen. Otherwise, information is returned about both the current and the previous range.
   /// </param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested artist statistics, if available.</returns>
+  /// <returns>The requested information, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IArtistStatistics?> GetArtistStatisticsAsync(int? count = null, int? offset = null, StatisticsRange? range = null,
@@ -191,7 +191,7 @@ public sealed partial class ListenBrainz {
   /// recorded listen. Otherwise, information is returned about both the current and the previous range.
   /// </param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested listening activity, if available.</returns>
+  /// <returns>The requested information, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IEraActivity?> GetEraActivityAsync(StatisticsRange? range = null, CancellationToken cancellationToken = default) {
@@ -210,7 +210,7 @@ public sealed partial class ListenBrainz {
   /// recorded listen. Otherwise, information is returned about both the current and the previous range.
   /// </param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested listening activity, if available.</returns>
+  /// <returns>The requested information, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IListeningActivity?> GetListeningActivityAsync(StatisticsRange? range = null,
@@ -235,7 +235,7 @@ public sealed partial class ListenBrainz {
   /// </param>
   /// <param name="range">The range of data to include in the statistics.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested recording statistics, if available.</returns>
+  /// <returns>The requested information, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IRecordingStatistics?> GetRecordingStatisticsAsync(int? count = null, int? offset = null,
@@ -263,7 +263,7 @@ public sealed partial class ListenBrainz {
   /// </param>
   /// <param name="range">The range of data to include in the statistics.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested releases statistics, if available.</returns>
+  /// <returns>The requested information, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IReleaseGroupStatistics?> GetReleaseGroupStatisticsAsync(int? count = null, int? offset = null,
@@ -289,7 +289,7 @@ public sealed partial class ListenBrainz {
   /// </param>
   /// <param name="range">The range of data to include in the statistics.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested releases statistics, if available.</returns>
+  /// <returns>The requested information, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IReleaseStatistics?> GetReleaseStatisticsAsync(int? count = null, int? offset = null,
@@ -369,7 +369,7 @@ public sealed partial class ListenBrainz {
   /// </param>
   /// <param name="range">The range of data to include in the statistics.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested artist statistics, if available.</returns>
+  /// <returns>The requested information, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IArtistStatistics?> GetArtistStatisticsAsync(string user, int? count = null, int? offset = null,
@@ -387,7 +387,7 @@ public sealed partial class ListenBrainz {
   /// <param name="user">The user for whom the information is requested.</param>
   /// <param name="range">The range of data to include in the information.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested daily activity, if available.</returns>
+  /// <returns>The requested information, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IUserDailyActivity?> GetDailyActivityAsync(string user, StatisticsRange? range = null,
@@ -409,7 +409,7 @@ public sealed partial class ListenBrainz {
   /// recorded listen. Otherwise, information is returned about both the current and the previous range.
   /// </param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested listening activity, if available.</returns>
+  /// <returns>The requested information, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IEraActivity?> GetEraActivityAsync(string user, StatisticsRange? range = null,
@@ -428,7 +428,7 @@ public sealed partial class ListenBrainz {
   /// <param name="user">The user for whom the information is requested.</param>
   /// <param name="range">The range of data to include in the information.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested listening activity, if available.</returns>
+  /// <returns>The requested information, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IGenreActivity?> GetGenreActivityAsync(string user, StatisticsRange? range = null,
@@ -449,7 +449,7 @@ public sealed partial class ListenBrainz {
   /// recorded listen. Otherwise, information is returned about both the current and the previous range.
   /// </param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested listening activity, if available.</returns>
+  /// <returns>The requested information, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IListeningActivity?> GetListeningActivityAsync(string user, StatisticsRange? range = null,
@@ -475,7 +475,7 @@ public sealed partial class ListenBrainz {
   /// </param>
   /// <param name="range">The range of data to include in the statistics.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested recording statistics, if available.</returns>
+  /// <returns>The requested information, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IRecordingStatistics?> GetRecordingStatisticsAsync(string user, int? count = null, int? offset = null,
@@ -502,7 +502,7 @@ public sealed partial class ListenBrainz {
   /// </param>
   /// <param name="range">The range of data to include in the statistics.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested releases statistics, if available.</returns>
+  /// <returns>The requested information, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IReleaseGroupStatistics?> GetReleaseGroupStatisticsAsync(string user, int? count = null, int? offset = null,
@@ -529,7 +529,7 @@ public sealed partial class ListenBrainz {
   /// </param>
   /// <param name="range">The range of data to include in the statistics.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <returns>The requested releases statistics, if available.</returns>
+  /// <returns>The requested information, if available.</returns>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task<IReleaseStatistics?> GetReleaseStatisticsAsync(string user, int? count = null, int? offset = null,
@@ -543,36 +543,24 @@ public sealed partial class ListenBrainz {
 
   #region /1/stats/user/xxx/year-in-music
 
-  // While the endpoint is listed in the docs, its payload is not.
-  // The top level has:
-  // - user_name: the name of the user
-  // - data: the year-in-music data, with the following fields:
-  //   - artist_map: same contents as the artist-map entry point (with the artist data limited to name, mbid and listen count)
-  //   - day_of_week: name of a day of the week; presumably the day the most listens are recorded
-  //   - listens_per_day: list of objects (one per day of the year):
-  //     - time_range: string containing the date (e.g. "02 October 2022")
-  //     - from_ts/to_ts: Unix timestamps
-  //     - listen_count
-  //   - most_listened_year: dictionary mapping a year (as a string) to the number of listens for recordings from that year
-  //   - new_releases_of_top_artists: list of release group info
-  //     - similar to what's in the RG stats, but "title" instead of "release_group_name", and no listen count
-  //   - playlist-top-discoveries-for-year
-  //     - ListenBrainz Troi playlist data
-  //   - playlist-top-discoveries-for-year-coverart: map of mbid to CAA URL
-  //   - playlist-top-missed-recordings-for-year
-  //     - ListenBrainz Troi playlist data
-  //   - playlist-top-missed-recordings-for-year-coverart: map of mbid to CAA URL
-  //   - similar_users: map of user names (string) to a decimal number (0-1)
-  //   - top_artists: list of artist info (similar to what's in the artist map: name, mbid, listen count)
-  //   - top_recordings: list of record info (similar to what's in the recording stats)
-  //   - top_releases: list of release info (similar to what's in the release stats)
-  //   - total_artists_count (an integer)
-  //   - total_listen_count (an integer)
-  //   - total_listening_time (a decimal number; presumably expressed in minutes)
-  //   - total_new_artists_discovered (an integer)
-  //   - total_recordings_count (an integer)
-  //   - total_releases_count (an integer)
-  //   - yim_artist_map: identical to artist_map
+  /// <summary>Gets information about a user's "Year in Music".</summary>
+  /// <param name="user">The user for whom the information is requested.</param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested information, if available.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IYearInMusic?> GetYearInMusicAsync(string user, CancellationToken cancellationToken = default)
+    => this.GetOptionalAsync<IYearInMusic, YearInMusic>($"stats/user/{user}/year-in-music", null, cancellationToken);
+
+  /// <summary>Gets information about a user's "Year in Music".</summary>
+  /// <param name="user">The user for whom the information is requested.</param>
+  /// <param name="year">The specific year to get data for.</param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The requested information, if available.</returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IYearInMusic?> GetYearInMusicAsync(string user, int year, CancellationToken cancellationToken = default)
+    => this.GetOptionalAsync<IYearInMusic, YearInMusic>($"stats/user/{user}/year-in-music/{year}", null, cancellationToken);
 
   #endregion
 

--- a/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.Statistics.cs
+++ b/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.Statistics.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Net.Http;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -37,7 +36,7 @@ public sealed partial class ListenBrainz {
     return options;
   }
 
-  #region /1/stats/.../artist-activity
+  #region /1/stats/sitewide/artist-activity
 
   /// <summary>Gets listening statistics for the top artists (and their albums) across all of ListenBrainz.</summary>
   /// <param name="range">The range of data to include in the statistics.</param>
@@ -50,6 +49,10 @@ public sealed partial class ListenBrainz {
     var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
     return this.GetOptionalAsync<IArtistActivity, ArtistActivity>("stats/sitewide/artist-activity", options, cancellationToken);
   }
+
+  #endregion
+
+  #region /1/stats/user/xxx/artist-activity
 
   /// <summary>Gets listening statistics for a user's top artists (and their albums).</summary>
   /// <param name="user">The user for whom the information is requested.</param>
@@ -66,7 +69,7 @@ public sealed partial class ListenBrainz {
 
   #endregion
 
-  #region /1/stats/.../artist-evolution-activity
+  #region /1/stats/sitewide/artist-evolution-activity
 
   /// <summary>Gets listening statistics for artists over time across all of ListenBrainz.</summary>
   /// <param name="range">
@@ -82,6 +85,10 @@ public sealed partial class ListenBrainz {
     var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
     return this.GetOptionalAsync<IArtistEvolutionActivity, ArtistEvolutionActivity>(address, options, cancellationToken);
   }
+
+  #endregion
+
+  #region /1/stats/user/xxx/artist-evolution-activity
 
   /// <summary>Gets a user's listening statistics for artists over time.</summary>
   /// <param name="user">The user for whom the information is requested.</param>
@@ -101,7 +108,7 @@ public sealed partial class ListenBrainz {
 
   #endregion
 
-  #region /1/stats/.../artist-map
+  #region /1/stats/sitewide/artist-map
 
   /// <summary>
   /// Gets information about the number of times artists are listened to across all of ListenBrainz, grouped by their country.
@@ -115,6 +122,10 @@ public sealed partial class ListenBrainz {
     var options = ListenBrainz.OptionsForGetArtistMap(range);
     return this.GetOptionalAsync<IArtistMap, ArtistMap>("stats/sitewide/artist-map", options, cancellationToken);
   }
+
+  #endregion
+
+  #region /1/stats/user/xxx/artist-map
 
   /// <summary>Gets information about the number of artists a user has listened to, grouped by their country.</summary>
   /// <param name="user">The user for whom the information is requested.</param>
@@ -131,7 +142,7 @@ public sealed partial class ListenBrainz {
 
   #endregion
 
-  #region /1/stats/.../artists
+  #region /1/stats/sitewide/artists
 
   /// <summary>Gets statistics about the most listened-to artists across all of ListenBrainz.</summary>
   /// <param name="count">
@@ -158,6 +169,10 @@ public sealed partial class ListenBrainz {
     return this.GetOptionalAsync<IArtistStatistics, ArtistStatistics>("stats/sitewide/artists", options, cancellationToken);
   }
 
+  #endregion
+
+  #region /1/stats/user/xxx/artists
+
   /// <summary>Gets statistics about a user's most listened-to artists.</summary>
   /// <param name="user">The user for whom the statistics are requested.</param>
   /// <param name="count">
@@ -182,7 +197,7 @@ public sealed partial class ListenBrainz {
 
   #endregion
 
-  #region /1/stats/.../daily-activity
+  #region /1/stats/user/xxx/daily-activity
 
   /// <summary>Gets information about how a user's listens are spread across the days of the week.</summary>
   /// <param name="user">The user for whom the information is requested.</param>
@@ -200,7 +215,7 @@ public sealed partial class ListenBrainz {
 
   #endregion
 
-  #region /1/stats/.../era-activity
+  #region /1/stats/sitewide/era-activity
 
   /// <summary>
   /// Gets information about how many listens have been recorded across all of ListenBrainz, grouped by their release year.
@@ -218,6 +233,10 @@ public sealed partial class ListenBrainz {
     var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
     return this.GetOptionalAsync<IEraActivity, EraActivity>("stats/sitewide/era-activity", options, cancellationToken);
   }
+
+  #endregion
+
+  #region /1/stats/user/xxx/era-activity
 
   /// <summary>Gets information about how many listens have been recorded for a user, grouped by their release year.</summary>
   /// <param name="user">The user for whom the information is requested.</param>
@@ -238,7 +257,7 @@ public sealed partial class ListenBrainz {
 
   #endregion
 
-  #region /1/stats/.../genre-activity
+  #region /1/stats/user/xxx/genre-activity
 
   /// <summary>
   /// Gets information about how many listens have been recorded for a user, grouped by the genre and the hour of the day.
@@ -257,7 +276,7 @@ public sealed partial class ListenBrainz {
 
   #endregion
 
-  #region /1/stats/.../listeners
+  #region /1/stats/artist/xxx/listeners
 
   /// <summary>Gets information about the top listeners for a particular artist.</summary>
   /// <param name="mbid">The MusicBrainz ID for the artist.</param>
@@ -285,6 +304,10 @@ public sealed partial class ListenBrainz {
     var options = ListenBrainz.OptionsForGetStatistics(count, offset, range);
     return this.GetOptionalAsync<IArtistListeners, ArtistListeners>($"stats/artist/{mbid}/listeners", options, cancellationToken);
   }
+
+  #endregion
+
+  #region /1/stats/release-group/xxx/listeners
 
   /// <summary>Gets information about the top listeners for a particular release group.</summary>
   /// <param name="mbid">The MusicBrainz ID for the release group.</param>
@@ -316,7 +339,7 @@ public sealed partial class ListenBrainz {
 
   #endregion
 
-  #region /1/stats/.../listening-activity
+  #region /1/stats/sitewide/listening-activity
 
   /// <summary>Gets information about how many listens have been submitted to ListenBrainz over a period of time.</summary>
   /// <param name="range">
@@ -334,6 +357,10 @@ public sealed partial class ListenBrainz {
     var options = ListenBrainz.OptionsForGetStatistics(null, null, range);
     return this.GetOptionalAsync<IListeningActivity, ListeningActivity>(address, options, cancellationToken);
   }
+
+  #endregion
+
+  #region /1/stats/user/xxx/listening-activity
 
   /// <summary>Gets information about how many listens a user has submitted to ListenBrainz over a period of time.</summary>
   /// <param name="user">The user for whom the information is requested.</param>
@@ -355,7 +382,7 @@ public sealed partial class ListenBrainz {
 
   #endregion
 
-  #region /1/stats/.../recordings
+  #region /1/stats/sitewide/recordings
 
   /// <summary>Gets statistics about the most listened-to recordings ("tracks") across all of ListenBrainz.</summary>
   /// <param name="count">
@@ -378,6 +405,10 @@ public sealed partial class ListenBrainz {
     var options = ListenBrainz.OptionsForGetStatistics(count, offset, range);
     return this.GetOptionalAsync<IRecordingStatistics, RecordingStatistics>(address, options, cancellationToken);
   }
+
+  #endregion
+
+  #region /1/stats/user/xxx/recordings
 
   /// <summary>Gets statistics about a user's most listened-to recordings ("tracks").</summary>
   /// <param name="user">The user for whom the statistics are requested.</param>
@@ -404,7 +435,7 @@ public sealed partial class ListenBrainz {
 
   #endregion
 
-  #region /1/stats/.../release-groups
+  #region /1/stats/sitewide/release-groups
 
   /// <summary>
   /// Gets statistics about the most listened-to release groups (sets of all editions of an "album") across all of ListenBrainz.
@@ -429,6 +460,10 @@ public sealed partial class ListenBrainz {
     var options = ListenBrainz.OptionsForGetStatistics(count, offset, range);
     return this.GetOptionalAsync<IReleaseGroupStatistics, ReleaseGroupStatistics>(address, options, cancellationToken);
   }
+
+  #endregion
+
+  #region /1/stats/user/xxx/release-groups
 
   /// <summary>Gets statistics about a user's most listened-to release groups (sets of all editions of an "album").</summary>
   /// <param name="user">The user for whom the statistics are requested.</param>
@@ -455,7 +490,7 @@ public sealed partial class ListenBrainz {
 
   #endregion
 
-  #region /1/stats/.../releases
+  #region /1/stats/sitewide/releases
 
   /// <summary>Gets statistics about the most listened-to releases ("albums") across all of ListenBrainz.</summary>
   /// <param name="count">
@@ -477,6 +512,10 @@ public sealed partial class ListenBrainz {
     var options = ListenBrainz.OptionsForGetStatistics(count, offset, range);
     return this.GetOptionalAsync<IReleaseStatistics, ReleaseStatistics>("stats/sitewide/releases", options, cancellationToken);
   }
+
+  #endregion
+
+  #region /1/stats/user/xxx/releases
 
   /// <summary>Gets statistics about a user's most listened-to releases ("albums").</summary>
   /// <param name="user">The user for whom the statistics are requested.</param>
@@ -502,7 +541,7 @@ public sealed partial class ListenBrainz {
 
   #endregion
 
-  #region /1/stats/.../year-in-music
+  #region /1/stats/user/xxx/year-in-music
 
   // While the endpoint is listed in the docs, its payload is not.
   // The top level has:

--- a/MetaBrainz.ListenBrainz/Objects/JSPF/Link.cs
+++ b/MetaBrainz.ListenBrainz/Objects/JSPF/Link.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+using MetaBrainz.ListenBrainz.Interfaces.JSPF;
+
+namespace MetaBrainz.ListenBrainz.Objects.JSPF;
+
+internal sealed class Link : ILink {
+
+  public required Uri Id { get; init; }
+
+  public required Uri Value { get; init; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/JSPF/Meta.cs
+++ b/MetaBrainz.ListenBrainz/Objects/JSPF/Meta.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+using MetaBrainz.ListenBrainz.Interfaces.JSPF;
+
+namespace MetaBrainz.ListenBrainz.Objects.JSPF;
+
+internal sealed class Meta : IMeta {
+
+  public required Uri Id { get; init; }
+
+  public required string Value { get; init; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/JSPF/MusicBrainzPlaylist.cs
+++ b/MetaBrainz.ListenBrainz/Objects/JSPF/MusicBrainzPlaylist.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces.JSPF;
+
+namespace MetaBrainz.ListenBrainz.Objects.JSPF;
+
+internal sealed class MusicBrainzPlaylist : JsonBasedObject, IMusicBrainzPlaylist {
+
+  public IReadOnlyDictionary<string, object?>? AdditionalMetadata { get; init; }
+
+  public IReadOnlyList<string>? Collaborators { get; init; }
+
+  public Uri? CopiedFrom { get; init; }
+
+  public bool? CopiedFromDeleted { get; init; }
+
+  public string? CreatedFor { get; init; }
+
+  public string? Creator { get; init; }
+
+  public DateTimeOffset? LastModified { get; init; }
+
+  public bool? Public { get; init; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/JSPF/MusicBrainzRecording.cs
+++ b/MetaBrainz.ListenBrainz/Objects/JSPF/MusicBrainzRecording.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces.JSPF;
+
+namespace MetaBrainz.ListenBrainz.Objects.JSPF;
+
+internal sealed class MusicBrainzRecording : JsonBasedObject, IMusicBrainzRecording {
+
+  public IReadOnlyList<Guid>? ArtistIds { get; init; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/JSPF/MusicBrainzTrack.cs
+++ b/MetaBrainz.ListenBrainz/Objects/JSPF/MusicBrainzTrack.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+using MetaBrainz.ListenBrainz.Interfaces.JSPF;
+
+namespace MetaBrainz.ListenBrainz.Objects.JSPF;
+
+internal sealed class MusicBrainzTrack : JsonBasedObject, IMusicBrainzTrack {
+
+  public DateTimeOffset? Added { get; init; }
+
+  public string? AddedBy { get; init; }
+
+  public IReadOnlyDictionary<string, object?>? AdditionalMetadata { get; init; }
+
+  public IReadOnlyList<Uri>? ArtistIds { get; init; }
+
+  public long? CoverArtId { get; init; }
+
+  public Guid? CoverArtReleaseId { get; init; }
+
+  public IReadOnlyList<IArtistCredit>? Credits { get; init; }
+
+  public Uri? ReleaseId { get; init; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/JSPF/NamedUri.cs
+++ b/MetaBrainz.ListenBrainz/Objects/JSPF/NamedUri.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+using MetaBrainz.ListenBrainz.Interfaces.JSPF;
+
+namespace MetaBrainz.ListenBrainz.Objects.JSPF;
+
+internal sealed class NamedUri : INamedUri {
+
+  public required string Name { get; init; }
+
+  public required Uri Uri { get; init; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/JSPF/Playlist.cs
+++ b/MetaBrainz.ListenBrainz/Objects/JSPF/Playlist.cs
@@ -32,6 +32,8 @@ internal sealed class Playlist : JsonBasedObject, IPlaylist {
 
   public IReadOnlyList<IMeta>? Metadata { get; init; }
 
+  public IMusicBrainzPlaylist? MusicBrainz { get; init; }
+
   public string? Title { get; init; }
 
   public required IReadOnlyList<ITrack> Tracks { get; init; }

--- a/MetaBrainz.ListenBrainz/Objects/JSPF/Playlist.cs
+++ b/MetaBrainz.ListenBrainz/Objects/JSPF/Playlist.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces.JSPF;
+
+namespace MetaBrainz.ListenBrainz.Objects.JSPF;
+
+internal sealed class Playlist : JsonBasedObject, IPlaylist {
+
+  public string? Annotation { get; init; }
+
+  public IReadOnlyList<INamedUri>? Attribution { get; init; }
+
+  public string? Creator { get; init; }
+
+  public DateTimeOffset? Date { get; init; }
+
+  public IReadOnlyDictionary<Uri, IReadOnlyList<object?>?>? Extensions { get; init; }
+
+  public Uri? Identifier { get; init; }
+
+  public Uri? Image { get; init; }
+
+  public Uri? Info { get; init; }
+
+  public Uri? License { get; init; }
+
+  public IReadOnlyList<ILink>? Links { get; init; }
+
+  public Uri? Location { get; init; }
+
+  public IReadOnlyList<IMeta>? Metadata { get; init; }
+
+  public string? Title { get; init; }
+
+  public required IReadOnlyList<ITrack> Tracks { get; init; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/JSPF/Track.cs
+++ b/MetaBrainz.ListenBrainz/Objects/JSPF/Track.cs
@@ -30,6 +30,10 @@ internal sealed class Track : JsonBasedObject, ITrack {
 
   public IReadOnlyList<IMeta>? Metadata { get; init; }
 
+  public IMusicBrainzTrack? MusicBrainz { get; init; }
+
+  public IMusicBrainzRecording? MusicBrainzRecording { get; init; }
+
   public string? Title { get; init; }
 
   public uint? TrackNumber { get; init; }

--- a/MetaBrainz.ListenBrainz/Objects/JSPF/Track.cs
+++ b/MetaBrainz.ListenBrainz/Objects/JSPF/Track.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces.JSPF;
+
+namespace MetaBrainz.ListenBrainz.Objects.JSPF;
+
+internal sealed class Track : JsonBasedObject, ITrack {
+
+  public string? Album { get; init; }
+
+  public string? Annotation { get; init; }
+
+  public string? Creator { get; init; }
+
+  public TimeSpan? Duration { get; init; }
+
+  public IReadOnlyDictionary<Uri, IReadOnlyList<object?>?>? Extensions { get; init; }
+
+  public IReadOnlyList<Uri>? Identifiers { get; init; }
+
+  public Uri? Image { get; init; }
+
+  public Uri? Info { get; init; }
+
+  public IReadOnlyList<ILink>? Links { get; init; }
+
+  public IReadOnlyList<Uri>? Locations { get; init; }
+
+  public IReadOnlyList<IMeta>? Metadata { get; init; }
+
+  public string? Title { get; init; }
+
+  public uint? TrackNumber { get; init; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/NewRelease.cs
+++ b/MetaBrainz.ListenBrainz/Objects/NewRelease.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal sealed class NewRelease : JsonBasedObject, INewRelease {
+
+  public long? CoverArtId { get; init; }
+
+  public Guid? CoverArtReleaseId { get; init; }
+
+  public string? CreditedArtist { get; init; }
+
+  public IReadOnlyList<Guid>? CreditedArtistIds { get; init; }
+
+  public IReadOnlyList<string>? CreditedArtistNames { get; init; }
+
+  public IReadOnlyList<IArtistCredit>? CreditedArtists { get; init; }
+
+  public string? FirstReleaseDate { get; init; }
+
+  public Guid? ReleaseId { get; init; }
+
+  public Guid? ReleaseGroupId { get; init; }
+
+  public required string Title { get; init; }
+
+  public string? Type { get; init; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/ReleaseGroupInfo.cs
+++ b/MetaBrainz.ListenBrainz/Objects/ReleaseGroupInfo.cs
@@ -14,7 +14,7 @@ internal sealed class ReleaseGroupInfo : JsonBasedObject, IReleaseGroupInfo {
 
   public long? CoverArtId { get; init; }
 
-  public Guid? CoverArtReleaseGroupId { get; init; }
+  public Guid? CoverArtReleaseId { get; init; }
 
   public IReadOnlyList<IArtistCredit>? Credits { get; init; }
 

--- a/MetaBrainz.ListenBrainz/Objects/ReleaseGroupListeners.cs
+++ b/MetaBrainz.ListenBrainz/Objects/ReleaseGroupListeners.cs
@@ -13,7 +13,7 @@ internal sealed class ReleaseGroupListeners : ListenerInfo, IReleaseGroupListene
 
   public long? CoverArtId { get; init; }
 
-  public Guid? CoverArtReleaseGroupId { get; init; }
+  public Guid? CoverArtReleaseId { get; init; }
 
   public required Guid Id { get; init; }
 

--- a/MetaBrainz.ListenBrainz/Objects/SimilarUser.cs
+++ b/MetaBrainz.ListenBrainz/Objects/SimilarUser.cs
@@ -1,0 +1,12 @@
+﻿using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal sealed class SimilarUser : JsonBasedObject, ISimilarUser {
+
+  public required string Name { get; init; }
+
+  public required decimal Similarity { get; init; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/TopArtist.cs
+++ b/MetaBrainz.ListenBrainz/Objects/TopArtist.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal class TopArtist : JsonBasedObject, ITopArtist {
+
+  public Guid? Id { get; init; }
+
+  public required int ListenCount { get; init; }
+
+  public required string Name { get; init; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/TopGenre.cs
+++ b/MetaBrainz.ListenBrainz/Objects/TopGenre.cs
@@ -1,0 +1,14 @@
+﻿using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal sealed class TopGenre : JsonBasedObject, ITopGenre {
+
+  public required string Genre { get; init; }
+
+  public required int ListenCount { get; init; }
+
+  public required decimal Percentage { get; init; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/TopRecording.cs
+++ b/MetaBrainz.ListenBrainz/Objects/TopRecording.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal sealed class TopRecording : JsonBasedObject, ITopRecording {
+
+  public IReadOnlyList<Guid>? ArtistIds { get; init; }
+
+  public string? ArtistName { get; init; }
+
+  public long? CoverArtId { get; init; }
+
+  public Guid? CoverArtReleaseGroupId { get; init; }
+
+  public IReadOnlyList<IArtistCredit>? Credits { get; init; }
+
+  public Guid? Id { get; init; }
+
+  public required int ListenCount { get; init; }
+
+  public required string Name { get; init; }
+
+  public Guid? ReleaseId { get; init; }
+
+  public string? ReleaseName { get; init; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/TopRecording.cs
+++ b/MetaBrainz.ListenBrainz/Objects/TopRecording.cs
@@ -14,7 +14,7 @@ internal sealed class TopRecording : JsonBasedObject, ITopRecording {
 
   public long? CoverArtId { get; init; }
 
-  public Guid? CoverArtReleaseGroupId { get; init; }
+  public Guid? CoverArtReleaseId { get; init; }
 
   public IReadOnlyList<IArtistCredit>? Credits { get; init; }
 

--- a/MetaBrainz.ListenBrainz/Objects/TopRelease.cs
+++ b/MetaBrainz.ListenBrainz/Objects/TopRelease.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal sealed class TopRelease : JsonBasedObject, ITopRelease {
+
+  public IReadOnlyList<Guid>? ArtistIds { get; init; }
+
+  public string? ArtistName { get; init; }
+
+  public long? CoverArtId { get; init; }
+
+  public Guid? CoverArtReleaseGroupId { get; init; }
+
+  public Guid? Id { get; init; }
+
+  public required int ListenCount { get; init; }
+
+  public required string Name { get; init; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/TopRelease.cs
+++ b/MetaBrainz.ListenBrainz/Objects/TopRelease.cs
@@ -14,7 +14,7 @@ internal sealed class TopRelease : JsonBasedObject, ITopRelease {
 
   public long? CoverArtId { get; init; }
 
-  public Guid? CoverArtReleaseGroupId { get; init; }
+  public Guid? CoverArtReleaseId { get; init; }
 
   public Guid? Id { get; init; }
 

--- a/MetaBrainz.ListenBrainz/Objects/YearInMusic.cs
+++ b/MetaBrainz.ListenBrainz/Objects/YearInMusic.cs
@@ -1,0 +1,12 @@
+﻿using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal sealed class YearInMusic : JsonBasedObject, IYearInMusic {
+
+  public required IYearInMusicData Data { get; init; }
+
+  public required string User { get; init; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/YearInMusicData.cs
+++ b/MetaBrainz.ListenBrainz/Objects/YearInMusicData.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 
 using MetaBrainz.Common.Json;
 using MetaBrainz.ListenBrainz.Interfaces;
+using MetaBrainz.ListenBrainz.Interfaces.JSPF;
 
 namespace MetaBrainz.ListenBrainz.Objects;
 
@@ -36,23 +37,23 @@ internal sealed class YearInMusicData : JsonBasedObject, IYearInMusicData {
 
   public IReadOnlyList<ITopArtist>? TopArtists { get; init; }
 
-  public object? TopDiscoveriesPlaylist { get; init; }
+  public IPlaylist? TopDiscoveriesPlaylist { get; init; }
 
   public IReadOnlyDictionary<string, Uri>? TopDiscoveriesPlaylistCoverArt { get; init; }
 
   public IReadOnlyList<ITopGenre>? TopGenres { get; init; }
 
-  public object? TopMissedRecordingsPlaylist { get; init; }
+  public IPlaylist? TopMissedRecordingsPlaylist { get; init; }
 
   public IReadOnlyDictionary<string, Uri>? TopMissedRecordingsPlaylistCoverArt { get; init; }
 
-  public object? TopNewRecordingsPlaylist { get; init; }
+  public IPlaylist? TopNewRecordingsPlaylist { get; init; }
 
   public IReadOnlyDictionary<string, Uri>? TopNewRecordingsPlaylistCoverArt { get; init; }
 
   public IReadOnlyList<ITopRecording>? TopRecordings { get; init; }
 
-  public object? TopRecordingsPlaylist { get; init; }
+  public IPlaylist? TopRecordingsPlaylist { get; init; }
 
   public IReadOnlyDictionary<string, Uri>? TopRecordingsPlaylistCoverArt { get; init; }
 

--- a/MetaBrainz.ListenBrainz/Objects/YearInMusicData.cs
+++ b/MetaBrainz.ListenBrainz/Objects/YearInMusicData.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal sealed class YearInMusicData : JsonBasedObject, IYearInMusicData {
+
+  public int? ArtistCount { get; init; }
+
+  public IReadOnlyList<IArtistCountryInfo>? ArtistMap { get; init; }
+
+  public string? DayOfWeek { get; init; }
+
+  public int? ListenCount { get; init; }
+
+  public TimeSpan? ListeningTime { get; init; }
+
+  public IReadOnlyList<IListenTimeRange>? ListensPerDay { get; init; }
+
+  public IReadOnlyDictionary<string, int>? MostListenedYear { get; init; }
+
+  public string? MostProminentColor { get; init; }
+
+  public int? NewArtistsDiscovered { get; init; }
+
+  public IReadOnlyList<INewRelease>? NewReleasesOfTopArtists { get; init; }
+
+  public int? RecordingCount { get; init; }
+
+  public int? ReleaseCount { get; init; }
+
+  public int? ReleaseGroupCount { get; init; }
+
+  public IReadOnlyList<ITopArtist>? TopArtists { get; init; }
+
+  public object? TopDiscoveriesPlaylist { get; init; }
+
+  public IReadOnlyDictionary<string, Uri>? TopDiscoveriesPlaylistCoverArt { get; init; }
+
+  public IReadOnlyList<ITopGenre>? TopGenres { get; init; }
+
+  public object? TopMissedRecordingsPlaylist { get; init; }
+
+  public IReadOnlyDictionary<string, Uri>? TopMissedRecordingsPlaylistCoverArt { get; init; }
+
+  public object? TopNewRecordingsPlaylist { get; init; }
+
+  public IReadOnlyDictionary<string, Uri>? TopNewRecordingsPlaylistCoverArt { get; init; }
+
+  public IReadOnlyList<ITopRecording>? TopRecordings { get; init; }
+
+  public object? TopRecordingsPlaylist { get; init; }
+
+  public IReadOnlyDictionary<string, Uri>? TopRecordingsPlaylistCoverArt { get; init; }
+
+  public IReadOnlyDictionary<string, decimal>? SimilarUsers { get; init; }
+
+  public IReadOnlyList<IReleaseGroupInfo>? TopReleaseGroups { get; init; }
+
+  public IReadOnlyList<ITopRelease>? TopReleases { get; init; }
+
+  public IReadOnlyDictionary<string, Uri>? TopReleasesCoverArt { get; init; }
+
+}

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -1567,7 +1567,7 @@ public interface IYearInMusicData : MetaBrainz.Common.Json.IJsonBasedObject {
     public abstract get;
   }
 
-  object? TopDiscoveriesPlaylist {
+  MetaBrainz.ListenBrainz.Interfaces.JSPF.IPlaylist? TopDiscoveriesPlaylist {
     public abstract get;
   }
 
@@ -1579,7 +1579,7 @@ public interface IYearInMusicData : MetaBrainz.Common.Json.IJsonBasedObject {
     public abstract get;
   }
 
-  object? TopMissedRecordingsPlaylist {
+  MetaBrainz.ListenBrainz.Interfaces.JSPF.IPlaylist? TopMissedRecordingsPlaylist {
     public abstract get;
   }
 
@@ -1587,7 +1587,7 @@ public interface IYearInMusicData : MetaBrainz.Common.Json.IJsonBasedObject {
     public abstract get;
   }
 
-  object? TopNewRecordingsPlaylist {
+  MetaBrainz.ListenBrainz.Interfaces.JSPF.IPlaylist? TopNewRecordingsPlaylist {
     public abstract get;
   }
 
@@ -1599,7 +1599,7 @@ public interface IYearInMusicData : MetaBrainz.Common.Json.IJsonBasedObject {
     public abstract get;
   }
 
-  object? TopRecordingsPlaylist {
+  MetaBrainz.ListenBrainz.Interfaces.JSPF.IPlaylist? TopRecordingsPlaylist {
     public abstract get;
   }
 
@@ -1632,6 +1632,180 @@ public interface IYearlyActivity : MetaBrainz.Common.Json.IJsonBasedObject {
   }
 
   int Year {
+    public abstract get;
+  }
+
+}
+```
+
+## Namespace: MetaBrainz.ListenBrainz.Interfaces.JSPF
+
+### Type: ILink
+
+```cs
+public interface ILink {
+
+  System.Uri Id {
+    public abstract get;
+  }
+
+  System.Uri Value {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IMeta
+
+```cs
+public interface IMeta {
+
+  System.Uri Id {
+    public abstract get;
+  }
+
+  string Value {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: INamedUri
+
+```cs
+public interface INamedUri {
+
+  string Name {
+    public abstract get;
+  }
+
+  System.Uri Uri {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IPlaylist
+
+```cs
+public interface IPlaylist : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  string? Annotation {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<INamedUri>? Attribution {
+    public abstract get;
+  }
+
+  string? Creator {
+    public abstract get;
+  }
+
+  System.DateTimeOffset? Date {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyDictionary<System.Uri, System.Collections.Generic.IReadOnlyList<object?>?>? Extensions {
+    public abstract get;
+  }
+
+  System.Uri? Identifier {
+    public abstract get;
+  }
+
+  System.Uri? Image {
+    public abstract get;
+  }
+
+  System.Uri? Info {
+    public abstract get;
+  }
+
+  System.Uri? License {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<ILink>? Links {
+    public abstract get;
+  }
+
+  System.Uri? Location {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IMeta>? Metadata {
+    public abstract get;
+  }
+
+  string? Title {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<ITrack> Tracks {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: ITrack
+
+```cs
+public interface ITrack : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  string? Album {
+    public abstract get;
+  }
+
+  string? Annotation {
+    public abstract get;
+  }
+
+  string? Creator {
+    public abstract get;
+  }
+
+  System.TimeSpan? Duration {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyDictionary<System.Uri, System.Collections.Generic.IReadOnlyList<object?>?>? Extensions {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<System.Uri>? Identifiers {
+    public abstract get;
+  }
+
+  System.Uri? Image {
+    public abstract get;
+  }
+
+  System.Uri? Info {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<ILink>? Links {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<System.Uri>? Locations {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IMeta>? Metadata {
+    public abstract get;
+  }
+
+  string? Title {
+    public abstract get;
+  }
+
+  uint? TrackNumber {
     public abstract get;
   }
 

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -192,6 +192,10 @@ public sealed class ListenBrainz : System.IDisposable {
 
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IReleaseStatistics?> GetReleaseStatisticsAsync(string user, int? count = default, int? offset = default, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
 
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IYearInMusic?> GetYearInMusicAsync(string user, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IYearInMusic?> GetYearInMusicAsync(string user, int year, System.Threading.CancellationToken cancellationToken = default);
+
   public System.Threading.Tasks.Task ImportListensAsync(params MetaBrainz.ListenBrainz.Interfaces.ISubmittedListen[] listens);
 
   public System.Threading.Tasks.Task ImportListensAsync(System.Collections.Generic.IAsyncEnumerable<MetaBrainz.ListenBrainz.Interfaces.ISubmittedListen> listens, System.Threading.CancellationToken cancellationToken = default);
@@ -862,6 +866,58 @@ public interface IMusicBrainzIdMappings {
 }
 ```
 
+### Type: INewRelease
+
+```cs
+public interface INewRelease {
+
+  long? CoverArtId {
+    public abstract get;
+  }
+
+  System.Guid? CoverArtReleaseId {
+    public abstract get;
+  }
+
+  string? CreditedArtist {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<System.Guid>? CreditedArtistIds {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<string>? CreditedArtistNames {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IArtistCredit>? CreditedArtists {
+    public abstract get;
+  }
+
+  string? FirstReleaseDate {
+    public abstract get;
+  }
+
+  System.Guid? ReleaseGroupId {
+    public abstract get;
+  }
+
+  System.Guid? ReleaseId {
+    public abstract get;
+  }
+
+  string Title {
+    public abstract get;
+  }
+
+  string? Type {
+    public abstract get;
+  }
+
+}
+```
+
 ### Type: IPlayingNow
 
 ```cs
@@ -973,7 +1029,7 @@ public interface IRecordingStatistics : IStatistics, MetaBrainz.Common.Json.IJso
 ### Type: IReleaseGroupInfo
 
 ```cs
-public interface IReleaseGroupInfo {
+public interface IReleaseGroupInfo : MetaBrainz.Common.Json.IJsonBasedObject {
 
   System.Collections.Generic.IReadOnlyList<System.Guid>? ArtistIds {
     public abstract get;
@@ -1130,6 +1186,22 @@ public interface IReleaseStatistics : IStatistics, MetaBrainz.Common.Json.IJsonB
 }
 ```
 
+### Type: ISimilarUser
+
+```cs
+public interface ISimilarUser : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  string Name {
+    public abstract get;
+  }
+
+  decimal Similarity {
+    public abstract get;
+  }
+
+}
+```
+
 ### Type: IStatistics
 
 ```cs
@@ -1234,6 +1306,46 @@ public interface ITokenValidationResult {
 }
 ```
 
+### Type: ITopArtist
+
+```cs
+public interface ITopArtist : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.Guid? Id {
+    public abstract get;
+  }
+
+  int ListenCount {
+    public abstract get;
+  }
+
+  string Name {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: ITopGenre
+
+```cs
+public interface ITopGenre : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  string Genre {
+    public abstract get;
+  }
+
+  int ListenCount {
+    public abstract get;
+  }
+
+  decimal Percentage {
+    public abstract get;
+  }
+
+}
+```
+
 ### Type: ITopListener
 
 ```cs
@@ -1244,6 +1356,90 @@ public interface ITopListener : MetaBrainz.Common.Json.IJsonBasedObject {
   }
 
   string UserName {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: ITopRecording
+
+```cs
+public interface ITopRecording : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.Collections.Generic.IReadOnlyList<System.Guid>? ArtistIds {
+    public abstract get;
+  }
+
+  string? ArtistName {
+    public abstract get;
+  }
+
+  long? CoverArtId {
+    public abstract get;
+  }
+
+  System.Guid? CoverArtReleaseGroupId {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IArtistCredit>? Credits {
+    public abstract get;
+  }
+
+  System.Guid? Id {
+    public abstract get;
+  }
+
+  int ListenCount {
+    public abstract get;
+  }
+
+  string Name {
+    public abstract get;
+  }
+
+  System.Guid? ReleaseId {
+    public abstract get;
+  }
+
+  string? ReleaseName {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: ITopRelease
+
+```cs
+public interface ITopRelease : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.Collections.Generic.IReadOnlyList<System.Guid>? ArtistIds {
+    public abstract get;
+  }
+
+  string? ArtistName {
+    public abstract get;
+  }
+
+  long? CoverArtId {
+    public abstract get;
+  }
+
+  System.Guid? CoverArtReleaseGroupId {
+    public abstract get;
+  }
+
+  System.Guid? Id {
+    public abstract get;
+  }
+
+  int ListenCount {
+    public abstract get;
+  }
+
+  string Name {
     public abstract get;
   }
 
@@ -1284,6 +1480,142 @@ public interface ITrackInfo : MetaBrainz.Common.Json.IJsonBasedObject {
 public interface IUserDailyActivity : IStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
 
   IDailyActivity? Activity {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IYearInMusic
+
+```cs
+public interface IYearInMusic : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  IYearInMusicData Data {
+    public abstract get;
+  }
+
+  string User {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IYearInMusicData
+
+```cs
+public interface IYearInMusicData : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  int? ArtistCount {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IArtistCountryInfo>? ArtistMap {
+    public abstract get;
+  }
+
+  string? DayOfWeek {
+    public abstract get;
+  }
+
+  int? ListenCount {
+    public abstract get;
+  }
+
+  System.TimeSpan? ListeningTime {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IListenTimeRange>? ListensPerDay {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyDictionary<string, int>? MostListenedYear {
+    public abstract get;
+  }
+
+  string? MostProminentColor {
+    public abstract get;
+  }
+
+  int? NewArtistsDiscovered {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<INewRelease>? NewReleasesOfTopArtists {
+    public abstract get;
+  }
+
+  int? RecordingCount {
+    public abstract get;
+  }
+
+  int? ReleaseCount {
+    public abstract get;
+  }
+
+  int? ReleaseGroupCount {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyDictionary<string, decimal>? SimilarUsers {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<ITopArtist>? TopArtists {
+    public abstract get;
+  }
+
+  object? TopDiscoveriesPlaylist {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyDictionary<string, System.Uri>? TopDiscoveriesPlaylistCoverArt {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<ITopGenre>? TopGenres {
+    public abstract get;
+  }
+
+  object? TopMissedRecordingsPlaylist {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyDictionary<string, System.Uri>? TopMissedRecordingsPlaylistCoverArt {
+    public abstract get;
+  }
+
+  object? TopNewRecordingsPlaylist {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyDictionary<string, System.Uri>? TopNewRecordingsPlaylistCoverArt {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<ITopRecording>? TopRecordings {
+    public abstract get;
+  }
+
+  object? TopRecordingsPlaylist {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyDictionary<string, System.Uri>? TopRecordingsPlaylistCoverArt {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IReleaseGroupInfo>? TopReleaseGroups {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<ITopRelease>? TopReleases {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyDictionary<string, System.Uri>? TopReleasesCoverArt {
     public abstract get;
   }
 

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -1672,6 +1672,98 @@ public interface IMeta {
 }
 ```
 
+### Type: IMusicBrainzPlaylist
+
+```cs
+public interface IMusicBrainzPlaylist {
+
+  System.Collections.Generic.IReadOnlyDictionary<string, object?>? AdditionalMetadata {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<string>? Collaborators {
+    public abstract get;
+  }
+
+  System.Uri? CopiedFrom {
+    public abstract get;
+  }
+
+  bool? CopiedFromDeleted {
+    public abstract get;
+  }
+
+  string? CreatedFor {
+    public abstract get;
+  }
+
+  string? Creator {
+    public abstract get;
+  }
+
+  System.DateTimeOffset? LastModified {
+    public abstract get;
+  }
+
+  bool? Public {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IMusicBrainzRecording
+
+```cs
+public interface IMusicBrainzRecording {
+
+  System.Collections.Generic.IReadOnlyList<System.Guid>? ArtistIds {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: IMusicBrainzTrack
+
+```cs
+public interface IMusicBrainzTrack : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.DateTimeOffset? Added {
+    public abstract get;
+  }
+
+  string? AddedBy {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyDictionary<string, object?>? AdditionalMetadata {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<System.Uri>? ArtistIds {
+    public abstract get;
+  }
+
+  long? CoverArtId {
+    public abstract get;
+  }
+
+  System.Guid? CoverArtReleaseId {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<MetaBrainz.ListenBrainz.Interfaces.IArtistCredit>? Credits {
+    public abstract get;
+  }
+
+  System.Uri? ReleaseId {
+    public abstract get;
+  }
+
+}
+```
+
 ### Type: INamedUri
 
 ```cs
@@ -1741,6 +1833,10 @@ public interface IPlaylist : MetaBrainz.Common.Json.IJsonBasedObject {
     public abstract get;
   }
 
+  IMusicBrainzPlaylist? MusicBrainz {
+    public abstract get;
+  }
+
   string? Title {
     public abstract get;
   }
@@ -1798,6 +1894,14 @@ public interface ITrack : MetaBrainz.Common.Json.IJsonBasedObject {
   }
 
   System.Collections.Generic.IReadOnlyList<IMeta>? Metadata {
+    public abstract get;
+  }
+
+  IMusicBrainzTrack? MusicBrainz {
+    public abstract get;
+  }
+
+  IMusicBrainzRecording? MusicBrainzRecording {
     public abstract get;
   }
 

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -1043,7 +1043,7 @@ public interface IReleaseGroupInfo : MetaBrainz.Common.Json.IJsonBasedObject {
     public abstract get;
   }
 
-  System.Guid? CoverArtReleaseGroupId {
+  System.Guid? CoverArtReleaseId {
     public abstract get;
   }
 
@@ -1083,7 +1083,7 @@ public interface IReleaseGroupListeners : IListenerInfo, IStatistics, MetaBrainz
     public abstract get;
   }
 
-  System.Guid? CoverArtReleaseGroupId {
+  System.Guid? CoverArtReleaseId {
     public abstract get;
   }
 
@@ -1379,7 +1379,7 @@ public interface ITopRecording : MetaBrainz.Common.Json.IJsonBasedObject {
     public abstract get;
   }
 
-  System.Guid? CoverArtReleaseGroupId {
+  System.Guid? CoverArtReleaseId {
     public abstract get;
   }
 
@@ -1427,7 +1427,7 @@ public interface ITopRelease : MetaBrainz.Common.Json.IJsonBasedObject {
     public abstract get;
   }
 
-  System.Guid? CoverArtReleaseGroupId {
+  System.Guid? CoverArtReleaseId {
     public abstract get;
   }
 


### PR DESCRIPTION
This adds support for the `/1/stats/user/xxx/year-in-music` and `/1/stats/user/xxx/year-in-music/nnnn` endpoints.

This includes a bunch of new data interfaces, including JSPF playlist related ones which will likely get reused for some of the playlist-oriented endpoints.

This renames the `CoverArtReleaseGroupId` property on `IReleaseGroupInfo` and `IReleaseGroupListeners` to `CoverArtReleaseId`, which is used for all other cases where that same piece of information is provided. ***This is a breaking change.***

This is the last part of a set of API additions, so it fixes #59.