### PR TITLE
Add LB Radio playlist generation support

### DIFF
--- a/MetaBrainz.ListenBrainz.sln.DotSettings
+++ b/MetaBrainz.ListenBrainz.sln.DotSettings
@@ -56,6 +56,7 @@
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_ARROW_WITH_EXPRESSIONS/@EntryValue">True</s:Boolean>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LIMIT/@EntryValue">132</s:Int64>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_OBJECT_AND_COLLECTION_INITIALIZER_STYLE/@EntryValue">CHOP_ALWAYS</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LB/@EntryIndexedValue">LB</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>

--- a/MetaBrainz.ListenBrainz/Interfaces/ILBRadioPlaylist.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ILBRadioPlaylist.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces.JSPF;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>An LB Radio recommendation playlist based on a user-supplied prompt.</summary>
+public interface ILBRadioPlaylist : IJsonBasedObject {
+
+  /// <summary>Feedback messages provided by the playlist generation.</summary>
+  IReadOnlyList<string> Feedback { get; }
+
+  /// <summary>The generated playlist.</summary>
+  IPlaylist Playlist { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Converters.cs
+++ b/MetaBrainz.ListenBrainz/Json/Converters.cs
@@ -19,6 +19,7 @@ internal static class Converters {
       yield return ErrorInfoReader.Instance;
       yield return FetchedListensReader.Instance;
       yield return GenreActivityReader.Instance;
+      yield return LBRadioPlaylistReader.Instance;
       yield return LatestImportReader.Instance;
       yield return ListenCountReader.Instance;
       yield return ListeningActivityReader.Instance;

--- a/MetaBrainz.ListenBrainz/Json/Readers/LBRadioPlaylistReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/LBRadioPlaylistReader.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+using MetaBrainz.ListenBrainz.Interfaces.JSPF;
+using MetaBrainz.ListenBrainz.Json.Readers.JSPF;
+using MetaBrainz.ListenBrainz.Objects;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers;
+
+internal sealed class LBRadioPlaylistReader : PayloadReader<LBRadioPlaylist> {
+
+  public static readonly LBRadioPlaylistReader Instance = new();
+
+  protected override LBRadioPlaylist ReadPayload(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    IReadOnlyList<string>? feedback = null;
+    IPlaylist? playlist = null;
+    Dictionary<string, object?>? rest = null;
+    while (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      try {
+        reader.Read();
+        switch (prop) {
+          case "feedback":
+            feedback = reader.ReadList<string>(options);
+            break;
+          case "jspf":
+            playlist = reader.GetObject(PlaylistReader.Instance, options);
+            break;
+          default:
+            rest ??= [ ];
+            rest[prop] = reader.GetOptionalObject(options);
+            break;
+        }
+      }
+      catch (Exception e) {
+        throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+      }
+      reader.Read();
+    }
+    return new LBRadioPlaylist {
+      Feedback = feedback ?? throw new MissingField("feedback"),
+      Playlist = playlist ?? throw new MissingField("jspf"),
+      UnhandledProperties = rest,
+    };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/LBRadioMode.cs
+++ b/MetaBrainz.ListenBrainz/LBRadioMode.cs
@@ -1,0 +1,18 @@
+﻿namespace MetaBrainz.ListenBrainz;
+
+/// <summary>Modes that can be used for generating LB Radio playlists.</summary>
+/// <seealso href="https://troi.readthedocs.io/en/latest/lb_radio.html#modes">Official Documentation</seealso>
+public enum LBRadioMode {
+
+  /// <summary>Easy mode picks recordings based on their own information.</summary>
+  Easy,
+
+  /// <summary>
+  /// Medium mode tries a bit harder to find matches; this will result in more diverse (and potentially less relevant) results.
+  /// </summary>
+  Medium,
+
+  /// <summary>Hard mode casts the widest net, finding even more diverse (and potentially less relevant) results.</summary>
+  Hard,
+
+}

--- a/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.Miscellaneous.cs
+++ b/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.Miscellaneous.cs
@@ -1,5 +1,40 @@
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+using MetaBrainz.Common;
+using MetaBrainz.ListenBrainz.Interfaces;
+using MetaBrainz.ListenBrainz.Objects;
+
 namespace MetaBrainz.ListenBrainz;
 
 public sealed partial class ListenBrainz {
+
+  #region /1/explore/lb-radio
+
+  /// <summary>Generates an LB Radio playlist based on a prompt.</summary>
+  /// <param name="prompt">
+  /// The LB radio prompt to use. See <a href="https://troi.readthedocs.io/en/latest/lb_radio.html">the official documentation</a>
+  /// for details.
+  /// </param>
+  /// <param name="mode">The generation mode to use.</param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>
+  /// The generated playlist. Note that this is not deterministic; multiple invocations with the same prompt may produce different
+  /// playlists.
+  /// </returns>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<ILBRadioPlaylist> CreateLBRadioPlaylistAsync(string prompt, LBRadioMode mode,
+                                                           CancellationToken cancellationToken = default) {
+    var options = new Dictionary<string, string> {
+      ["prompt"] = prompt,
+      ["mode"] = mode.ToString().ToLowerInvariant(),
+    };
+    return this.GetAsync<ILBRadioPlaylist, LBRadioPlaylist>("explore/lb-radio", options, cancellationToken);
+  }
+
+  #endregion
 
 }

--- a/MetaBrainz.ListenBrainz/ListenBrainz.Internals.cs
+++ b/MetaBrainz.ListenBrainz/ListenBrainz.Internals.cs
@@ -163,8 +163,8 @@ public sealed partial class ListenBrainz {
     var sb = new StringBuilder();
     var separator = '?';
     foreach (var option in options) {
-      // FIXME: Which parts (if any) need URL/Data escaping?
-      sb.Append(separator).Append(option.Key).Append('=').Append(option.Value);
+      // Assumption: the keys will always be simple snake or kebab case and therefore never need escaping.
+      sb.Append(separator).Append(option.Key).Append('=').Append(Uri.EscapeDataString(option.Value));
       separator = '&';
     }
     return sb.ToString();

--- a/MetaBrainz.ListenBrainz/Objects/LBRadioPlaylist.cs
+++ b/MetaBrainz.ListenBrainz/Objects/LBRadioPlaylist.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+using MetaBrainz.ListenBrainz.Interfaces.JSPF;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal sealed class LBRadioPlaylist : JsonBasedObject, ILBRadioPlaylist {
+
+  public required IReadOnlyList<string> Feedback { get; init; }
+
+  public required IPlaylist Playlist { get; init; }
+
+}

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -9,6 +9,18 @@
 
 ## Namespace: MetaBrainz.ListenBrainz
 
+### Type: LBRadioMode
+
+```cs
+public enum LBRadioMode {
+
+  Easy = 0,
+  Hard = 2,
+  Medium = 1,
+
+}
+```
+
 ### Type: ListenBrainz
 
 ```cs
@@ -123,6 +135,8 @@ public sealed class ListenBrainz : System.IDisposable {
   public void ConfigureClient(System.Action<System.Net.Http.HttpClient>? code);
 
   public void ConfigureClientCreation(System.Func<System.Net.Http.HttpClient>? code);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.ILBRadioPlaylist> CreateLBRadioPlaylistAsync(string prompt, LBRadioMode mode, System.Threading.CancellationToken cancellationToken = default);
 
   public sealed override void Dispose();
 
@@ -728,6 +742,22 @@ public interface ILatestImport : MetaBrainz.Common.Json.IJsonBasedObject {
   }
 
   string? User {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: ILBRadioPlaylist
+
+```cs
+public interface ILBRadioPlaylist : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.Collections.Generic.IReadOnlyList<string> Feedback {
+    public abstract get;
+  }
+
+  MetaBrainz.ListenBrainz.Interfaces.JSPF.IPlaylist Playlist {
     public abstract get;
   }
 


### PR DESCRIPTION
This adds support for the `/1/explore/lb-radio` endpoint.

In addition, parameter values for requests are now encoded properly (has not mattered much so far, but for LB radio prompts it does).