### PR TITLE
Add methods for recording feedback endpoints

### DIFF
--- a/MetaBrainz.ListenBrainz/Interfaces/IFoundFeedback.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IFoundFeedback.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+using MetaBrainz.Common.Json;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>The results of a feedback search.</summary>
+public interface IFoundFeedback : IJsonBasedObject {
+
+  /// <summary>The maximum number of matches returned.</summary>
+  public int Count { get; }
+
+  /// <summary>The (0-based) offset of the returned feedback items from the start of the full set.</summary>
+  public int Offset { get; }
+
+  /// <summary>The feedback items that were found (if any).</summary>
+  public IReadOnlyList<IRecordingFeedback> Feedback { get; }
+
+  /// <summary>The total number of matching feedback items.</summary>
+  public int TotalCount { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/IRecordingFeedback.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IRecordingFeedback.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+using MetaBrainz.Common.Json;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>Feedback given to a recording.</summary>
+public interface IRecordingFeedback : IJsonBasedObject {
+
+  /// <summary>The timestamp for the creation of this feedback.</summary>
+  public DateTimeOffset Created { get; }
+
+  /// <summary>The MusicBrainz ID identifying the recording.</summary>
+  public Guid? Id { get; }
+
+  /// <summary>The MessyBrainz ID identifying the recording.</summary>
+  public Guid? MessyId { get; }
+
+  /// <summary>The feedback score assigned by the user. 1 means they loved the recording; -1 means they hated it.</summary>
+  public int Score { get; }
+
+  /// <summary>Extra metadata for the track.</summary>
+  /// <remarks>
+  /// This field is undocumented, but is currently returned by the feedback retrieval endpoints. It is expected to mostly (always?)
+  /// be <see langword="null"/>.
+  /// </remarks>
+  public object? TrackMetadata { get; }
+
+  /// <summary>The user who submitted this feedback.</summary>
+  public string User { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Interfaces/ISubmittedRecordingFeedback.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ISubmittedRecordingFeedback.cs
@@ -1,0 +1,40 @@
+﻿using System;
+
+namespace MetaBrainz.ListenBrainz.Interfaces;
+
+/// <summary>Feedback to submit for a recording.</summary>
+public interface ISubmittedRecordingFeedback {
+
+  /// <summary>The MusicBrainz ID identifying the recording for which feedback is being provided.</summary>
+  /// <remarks>When submitting, at least one of this property and <see cref="MessyId"/> must be set.</remarks>
+  public Guid? Id { get; }
+
+  /// <summary>The MessyBrainz ID identifying the recording for which feedback is being provided.</summary>
+  /// <remarks>When submitting, at least one of this property and <see cref="Id"/> must be set.</remarks>
+  public Guid? MessyId { get; }
+
+  /// <summary>
+  /// The score to submit.<br/>
+  /// This must be one of the following values:
+  /// <list type="table">
+  ///   <listheader>
+  ///     <term>Score</term>
+  ///     <description>Action</description>
+  ///   </listheader>
+  ///   <item>
+  ///     <term>0</term>
+  ///     <description>Remove existing feedback.</description>
+  ///   </item>
+  ///   <item>
+  ///     <term>1</term>
+  ///     <description>Mark recording as loved.</description>
+  ///   </item>
+  ///   <item>
+  ///     <term>-1</term>
+  ///     <description>Mark recording as hated.</description>
+  ///   </item>
+  /// </list>
+  /// </summary>
+  public int Score { get; }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Converters.cs
+++ b/MetaBrainz.ListenBrainz/Json/Converters.cs
@@ -19,6 +19,7 @@ internal static class Converters {
       yield return EraActivityReader.Instance;
       yield return ErrorInfoReader.Instance;
       yield return FetchedListensReader.Instance;
+      yield return FoundFeedbackReader.Instance;
       yield return FoundPlaylistsReader.Instance;
       yield return GenreActivityReader.Instance;
       yield return LBRadioPlaylistReader.Instance;
@@ -41,6 +42,7 @@ internal static class Converters {
     get {
       yield return ListenPayloadWriter.Instance;
       yield return ListenDataPayloadWriter.Instance;
+      yield return RecordingFeedbackWriter.Instance;
     }
   }
 

--- a/MetaBrainz.ListenBrainz/Json/Readers/FoundFeedbackReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/FoundFeedbackReader.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.Common.Json.Converters;
+using MetaBrainz.ListenBrainz.Interfaces;
+using MetaBrainz.ListenBrainz.Objects;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers;
+
+internal sealed class FoundFeedbackReader : ObjectReader<FoundFeedback> {
+
+  public static readonly FoundFeedbackReader Instance = new();
+
+  protected override FoundFeedback ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options)  {
+    int? count = null;
+    int? offset = null;
+    IReadOnlyList<IRecordingFeedback>? feedback = null;
+    int? totalCount = null;
+    Dictionary<string, object?>? rest = null;
+    while (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      try {
+        reader.Read();
+        switch (prop) {
+          case "count":
+            count = reader.GetInt32();
+            break;
+          case "feedback":
+            feedback = reader.ReadList(RecordingFeedbackReader.Instance, options);
+            break;
+          case "offset":
+            offset = reader.GetInt32();
+            break;
+          case "total_count":
+            totalCount = reader.GetInt32();
+            break;
+          default:
+            rest ??= [ ];
+            rest[prop] = reader.GetOptionalObject(options);
+            break;
+        }
+      }
+      catch (Exception e) {
+        throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+      }
+      reader.Read();
+    }
+    return new FoundFeedback {
+      Count = count ?? throw new MissingField("count"),
+      Feedback = feedback ?? throw new MissingField("feedback"),
+      Offset = offset ?? throw new MissingField("offset"),
+      TotalCount = totalCount ?? throw new MissingField("playlist_count"),
+      UnhandledProperties = rest,
+    };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Readers/RecordingFeedbackReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/RecordingFeedbackReader.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.Common.Json.Converters;
+using MetaBrainz.ListenBrainz.Objects;
+
+namespace MetaBrainz.ListenBrainz.Json.Readers;
+
+internal sealed class RecordingFeedbackReader : ObjectReader<RecordingFeedback> {
+
+  public static readonly RecordingFeedbackReader Instance = new();
+
+  protected override RecordingFeedback ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    long? created = null;
+    Guid? mbid = null;
+    Guid? msid = null;
+    int? score = null;
+    object? trackMetadata = null;
+    string? user = null;
+    Dictionary<string, object?>? rest = null;
+    while (reader.TokenType == JsonTokenType.PropertyName) {
+      var prop = reader.GetPropertyName();
+      try {
+        reader.Read();
+        switch (prop) {
+          case "created":
+            created = reader.GetOptionalInt64();
+            break;
+          case "recording_mbid":
+            mbid = reader.GetOptionalGuid();
+            break;
+          case "recording_msid":
+            msid = reader.GetOptionalGuid();
+            break;
+          case "score":
+            score = reader.GetOptionalInt32();
+            break;
+          case "track_metadata":
+            trackMetadata = reader.GetOptionalObject(options);
+            break;
+          case "user_id":
+            user = reader.GetString();
+            break;
+          default:
+            rest ??= [ ];
+            rest[prop] = reader.GetOptionalObject(options);
+            break;
+        }
+      }
+      catch (Exception e) {
+        throw new JsonException($"Failed to deserialize the '{prop}' property.", e);
+      }
+      reader.Read();
+    }
+    if (created is null) {
+      throw new JsonException("Expected created timestamp not found or null.");
+    }
+    return new RecordingFeedback {
+      Created = DateTimeOffset.FromUnixTimeSeconds(created.Value),
+      Id = mbid,
+      MessyId = msid,
+      Score = score ?? throw new JsonException("Expected score not found or null."),
+      TrackMetadata = trackMetadata,
+      UnhandledProperties = rest,
+      User = user ?? throw new JsonException("Expected user name not found or null."),
+    };
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/Json/Writers/RecordingFeedbackWriter.cs
+++ b/MetaBrainz.ListenBrainz/Json/Writers/RecordingFeedbackWriter.cs
@@ -1,0 +1,23 @@
+﻿using System.Text.Json;
+
+using MetaBrainz.Common.Json.Converters;
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Json.Writers;
+
+internal sealed class RecordingFeedbackWriter : ObjectWriter<ISubmittedRecordingFeedback> {
+
+  public static readonly RecordingFeedbackWriter Instance = new();
+
+  protected override void WriteObjectContents(Utf8JsonWriter writer, ISubmittedRecordingFeedback value,
+                                              JsonSerializerOptions options) {
+    if (value.Id is not null) {
+      writer.WriteString("recording_mbid", value.Id.Value);
+    }
+    if (value.MessyId is not null) {
+      writer.WriteString("recording_msid", value.MessyId.Value);
+    }
+    writer.WriteNumber("score", value.Score);
+  }
+
+}

--- a/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.Core.cs
+++ b/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.Core.cs
@@ -77,8 +77,7 @@ public sealed partial class ListenBrainz {
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
   /// <return>A task that will perform the operation.</return>
   /// <remarks>
-  /// This will access the <c>POST /1/submit-listens</c> endpoint.<br/>
-  /// Users can find their token on <a href="https://listenbrainz.org/profile/">their profile page</a>.<br/>
+  /// This will access the <c>POST /1/submit-listens</c> endpoint and requires <see cref="UserToken"/> to be set.<br/>
   /// Submissions will happen every <see cref="MaxListensPerRequest"/> listens. As such, one call to this method may result in
   /// multiple web service requests, which may affect rate limiting.
   /// </remarks>
@@ -103,8 +102,7 @@ public sealed partial class ListenBrainz {
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
   /// <return>A task that will perform the operation.</return>
   /// <remarks>
-  /// This will access the <c>POST /1/submit-listens</c> endpoint.<br/>
-  /// Users can find their token on <a href="https://listenbrainz.org/profile/">their profile page</a>.<br/>
+  /// This will access the <c>POST /1/submit-listens</c> endpoint and requires <see cref="UserToken"/> to be set.<br/>
   /// Submissions will happen every <see cref="MaxListensPerRequest"/> listens. As such, one call to this method may result in
   /// multiple web service requests, which may affect rate limiting.
   /// </remarks>
@@ -135,8 +133,7 @@ public sealed partial class ListenBrainz {
   /// <param name="listens">The listens to import.</param>
   /// <return>A task that will perform the operation.</return>
   /// <remarks>
-  /// This will access the <c>POST /1/submit-listens</c> endpoint.<br/>
-  /// Users can find their token on <a href="https://listenbrainz.org/profile/">their profile page</a>.<br/>
+  /// This will access the <c>POST /1/submit-listens</c> endpoint and requires <see cref="UserToken"/> to be set.<br/>
   /// Submissions will happen every <see cref="MaxListensPerRequest"/> listens. As such, one call to this method may result in
   /// multiple web service requests, which may affect rate limiting.
   /// </remarks>
@@ -149,8 +146,7 @@ public sealed partial class ListenBrainz {
   /// <param name="listens">The listens to import.</param>
   /// <return>A task that will perform the operation.</return>
   /// <remarks>
-  /// This will access the <c>POST /1/submit-listens</c> endpoint.<br/>
-  /// Users can find their token on <a href="https://listenbrainz.org/profile/">their profile page</a>.<br/>
+  /// This will access the <c>POST /1/submit-listens</c> endpoint and requires <see cref="UserToken"/> to be set.<br/>
   /// Submissions will happen every <see cref="MaxListensPerRequest"/> listens. As such, one call to this method may result in
   /// multiple web service requests, which may affect rate limiting.
   /// </remarks>
@@ -194,11 +190,7 @@ public sealed partial class ListenBrainz {
   /// <param name="listen">The listen data to send.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
   /// <return>A task that will perform the operation.</return>
-  /// <remarks>
-  /// This will access the <c>POST /1/submit-listens</c> endpoint.<br/>
-  /// Users can find their token on their profile page:
-  /// <a href="https://listenbrainz.org/profile/">https://listenbrainz.org/profile/</a>.
-  /// </remarks>
+  /// <remarks>This will access the <c>POST /1/submit-listens</c> endpoint and requires <see cref="UserToken"/> to be set.</remarks>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task SetNowPlayingAsync(ISubmittedListenData listen, CancellationToken cancellationToken = default)
@@ -210,11 +202,7 @@ public sealed partial class ListenBrainz {
   /// <param name="release">The name of the release containing the track being listened to.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
   /// <return>A task that will perform the operation.</return>
-  /// <remarks>
-  /// This will access the <c>POST /1/submit-listens</c> endpoint.<br/>
-  /// Users can find their token on their profile page:
-  /// <a href="https://listenbrainz.org/profile/">https://listenbrainz.org/profile/</a>.
-  /// </remarks>
+  /// <remarks>This will access the <c>POST /1/submit-listens</c> endpoint and requires <see cref="UserToken"/> to be set.</remarks>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   [Obsolete("Create a SubmittedListenData and pass it to the overload taking an ISubmittedListenData instead.")]
@@ -239,11 +227,7 @@ public sealed partial class ListenBrainz {
   /// <param name="listen">The listen data to send.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
   /// <return>A task that will perform the operation.</return>
-  /// <remarks>
-  /// This will access the <c>POST /1/submit-listens</c> endpoint.<br/>
-  /// Users can find their token on their profile page:
-  /// <a href="https://listenbrainz.org/profile/">https://listenbrainz.org/profile/</a>.
-  /// </remarks>
+  /// <remarks>This will access the <c>POST /1/submit-listens</c> endpoint and requires <see cref="UserToken"/> to be set.</remarks>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   public Task SubmitSingleListenAsync(ISubmittedListen listen, CancellationToken cancellationToken = default)
@@ -258,11 +242,7 @@ public sealed partial class ListenBrainz {
   /// <param name="release">The name of the release containing the track being listened to.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
   /// <return>A task that will perform the operation.</return>
-  /// <remarks>
-  /// This will access the <c>POST /1/submit-listens</c> endpoint.<br/>
-  /// Users can find their token on their profile page:
-  /// <a href="https://listenbrainz.org/profile/">https://listenbrainz.org/profile/</a>.
-  /// </remarks>
+  /// <remarks>This will access the <c>POST /1/submit-listens</c> endpoint and requires <see cref="UserToken"/> to be set.</remarks>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   [Obsolete("Create a SubmittedListen and pass it to the overload taking an ISubmittedListen instead.")]
@@ -290,11 +270,7 @@ public sealed partial class ListenBrainz {
   /// <param name="release">The name of the release containing the track being listened to.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
   /// <return>A task that will perform the operation.</return>
-  /// <remarks>
-  /// This will access the <c>POST /1/submit-listens</c> endpoint.<br/>
-  /// Users can find their token on their profile page:
-  /// <a href="https://listenbrainz.org/profile/">https://listenbrainz.org/profile/</a>.
-  /// </remarks>
+  /// <remarks>This will access the <c>POST /1/submit-listens</c> endpoint and requires <see cref="UserToken"/> to be set.</remarks>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   [Obsolete("Create a SubmittedListen and pass it to the overload taking an ISubmittedListen instead.")]
@@ -318,11 +294,7 @@ public sealed partial class ListenBrainz {
   /// <param name="artist">The name of the artist performing the track being listened to.</param>
   /// <param name="release">The name of the release containing the track being listened to.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
-  /// <remarks>
-  /// This will access the <c>POST /1/submit-listens</c> endpoint.<br/>
-  /// Users can find their token on their profile page:
-  /// <a href="https://listenbrainz.org/profile/">https://listenbrainz.org/profile/</a>.
-  /// </remarks>
+  /// <remarks>This will access the <c>POST /1/submit-listens</c> endpoint and requires <see cref="UserToken"/> to be set.</remarks>
   /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
   /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
   [Obsolete("Create a SubmittedListen and pass it to the overload taking an ISubmittedListen instead.")]

--- a/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.Recordings.cs
+++ b/MetaBrainz.ListenBrainz/ListenBrainz.EndPoints.Recordings.cs
@@ -1,5 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+using MetaBrainz.Common;
+using MetaBrainz.ListenBrainz.Interfaces;
+using MetaBrainz.ListenBrainz.Objects;
+
 namespace MetaBrainz.ListenBrainz;
 
 public sealed partial class ListenBrainz {
+
+  private static Dictionary<string, string> OptionsForFeedback(int? score, int? count, int? offset) {
+    var options = new Dictionary<string, string>(3);
+    if (score is not null) {
+      if (score is not (1 or -1)) {
+        const string msg = "The score must be either 1 (to return only loved recordings) or -1 (to return only hated recordings).";
+        throw new ArgumentOutOfRangeException(nameof(score), score, msg);
+      }
+      options.Add("score", score.Value.ToString(CultureInfo.InvariantCulture));
+    }
+    if (count is not null) {
+      options.Add("count", count.Value.ToString(CultureInfo.InvariantCulture));
+    }
+    if (offset is not null) {
+      options.Add("offset", offset.Value.ToString(CultureInfo.InvariantCulture));
+    }
+    return options;
+  }
+
+  #region /1/feedback/recording/xxx/get-feedback
+
+  /// <summary>Gets feedback logged for a recording.</summary>
+  /// <param name="msid">The MessyBrainz ID identifying the recording.</param>
+  /// <param name="score">
+  /// Specify this as 1 to only return information about users who loved the recording; specify it as -1 for those who hated it.
+  /// </param>
+  /// <param name="count">
+  /// The (maximum) number of results to return. If not specified (or <see langword="null"/>), up to
+  /// <seealso cref="DefaultItemsPerGet"/> will be returned. Values over <see cref="MaxItemsPerGet"/> will be treated as if they
+  /// were exactly <see cref="MaxItemsPerGet"/>.
+  /// </param>
+  /// <param name="offset">
+  /// The offset (from the start of the results) of the matching feedback items to return. If this is equal to or higher than the
+  /// total number of matches, no results will be returned.
+  /// </param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The feedback that was found (if any).</returns>
+  /// <exception cref="ArgumentOutOfRangeException">
+  /// When <paramref name="score"/> is specified with a value other than 1 or -1.
+  /// </exception>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IFoundFeedback> GetFeedbackForMessyRecordingAsync(Guid msid, int? score = null, int? count = null, int? offset = null,
+                                                                CancellationToken cancellationToken = default) {
+    var options = ListenBrainz.OptionsForFeedback(score, count, offset);
+    return this.GetAsync<IFoundFeedback, FoundFeedback>($"feedback/recording/{msid}/get-feedback", options, cancellationToken);
+  }
+
+  #endregion
+
+  #region /1/feedback/recording/xxx/get-feedback-mbid
+
+  /// <summary>Gets feedback logged for a recording.</summary>
+  /// <param name="mbid">The MusicBrainz ID identifying the recording.</param>
+  /// <param name="score">
+  /// Specify this as 1 to only return information about users who loved the recording; specify it as -1 for those who hated it.
+  /// </param>
+  /// <param name="count">
+  /// The (maximum) number of results to return. If not specified (or <see langword="null"/>), up to
+  /// <seealso cref="DefaultItemsPerGet"/> will be returned. Values over <see cref="MaxItemsPerGet"/> will be treated as if they
+  /// were exactly <see cref="MaxItemsPerGet"/>.
+  /// </param>
+  /// <param name="offset">
+  /// The offset (from the start of the results) of the matching feedback items to return. If this is equal to or higher than the
+  /// total number of matches, no results will be returned.
+  /// </param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The feedback that was found (if any).</returns>
+  /// <exception cref="ArgumentOutOfRangeException">
+  /// When <paramref name="score"/> is specified with a value other than 1 or -1.
+  /// </exception>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task<IFoundFeedback> GetFeedbackForRecordingAsync(Guid mbid, int? score = null, int? count = null, int? offset = null,
+                                                           CancellationToken cancellationToken = default) {
+    var options = ListenBrainz.OptionsForFeedback(score, count, offset);
+    return this.GetAsync<IFoundFeedback, FoundFeedback>($"feedback/recording/{mbid}/get-feedback-mbid", options, cancellationToken);
+  }
+
+  #endregion
+
+  #region /1/feedback/recording-feedback
+
+  /// <summary>Submits recording feedback for the user whose token is set in <see cref="UserToken"/>.</summary>
+  /// <param name="feedback">
+  /// The feedback to submit.<br/>
+  /// At least one of its <see cref="ISubmittedRecordingFeedback.Id"/> and <see cref="ISubmittedRecordingFeedback.MessyId"/>
+  /// properties must be set.
+  /// </param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <return>A task that will perform the operation.</return>
+  /// <remarks>
+  /// This will access the <c>POST /1/feedback/recording-feedback</c> endpoint and requires <see cref="UserToken"/> to be set.<br/>
+  /// Users can find their token on <a href="https://listenbrainz.org/profile/">their profile page</a>.<br/>
+  /// </remarks>
+  /// <exception cref="ArgumentException">
+  /// When neither the <see cref="ISubmittedRecordingFeedback.Id"/> nor the <see cref="ISubmittedRecordingFeedback.MessyId"/>
+  /// property is set on <paramref name="feedback"/>.
+  /// </exception>
+  /// <exception cref="HttpRequestException">When there was a problem sending the web service request.</exception>
+  /// <exception cref="HttpError">When the web service sends a response indicating an error.</exception>
+  public Task SubmitRecordingFeedbackAsync(ISubmittedRecordingFeedback feedback, CancellationToken cancellationToken = default) {
+    if (feedback.Id is null && feedback.MessyId is null) {
+      throw new ArgumentException("At least one recording ID must be specified (MBID, MSID, or both).", nameof(feedback));
+    }
+    return this.PostAsync("feedback/recording-feedback", feedback, null, cancellationToken);
+  }
+
+  #endregion
 
 }

--- a/MetaBrainz.ListenBrainz/Objects/FoundFeedback.cs
+++ b/MetaBrainz.ListenBrainz/Objects/FoundFeedback.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal sealed class FoundFeedback : JsonBasedObject, IFoundFeedback {
+
+  public required int Count { get; init; }
+
+  public required int Offset { get; init; }
+
+  public required IReadOnlyList<IRecordingFeedback> Feedback { get; init; }
+
+  public required int TotalCount { get; init; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/RecordingFeedback.cs
+++ b/MetaBrainz.ListenBrainz/Objects/RecordingFeedback.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+using MetaBrainz.Common.Json;
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+internal sealed class RecordingFeedback : JsonBasedObject, IRecordingFeedback {
+
+  public required DateTimeOffset Created { get; init; }
+
+  public required Guid? Id { get; init; }
+
+  public required Guid? MessyId { get; init; }
+
+  public required int Score { get; init; }
+
+  public required object? TrackMetadata { get; init; }
+
+  public required string User { get; init; }
+
+}

--- a/MetaBrainz.ListenBrainz/Objects/SubmittedRecordingFeedback.cs
+++ b/MetaBrainz.ListenBrainz/Objects/SubmittedRecordingFeedback.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+using JetBrains.Annotations;
+
+using MetaBrainz.ListenBrainz.Interfaces;
+
+namespace MetaBrainz.ListenBrainz.Objects;
+
+/// <inheritdoc />
+[PublicAPI]
+public sealed class SubmittedRecordingFeedback : ISubmittedRecordingFeedback {
+
+  /// <inheritdoc />
+  public Guid? Id { get; set; }
+
+  /// <inheritdoc />
+  public Guid? MessyId { get; set; }
+
+  /// <inheritdoc />
+  public int Score {
+    get;
+    set {
+      if (value is < -1 or > 1) {
+        throw new ArgumentOutOfRangeException(nameof(this.Score), value,
+                                              "The score must be either -1 (hate), 0 (remove feedback) or 1 (love).");
+      }
+      field = value;
+    }
+  }
+
+}

--- a/public-api/MetaBrainz.ListenBrainz.net10.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net10.0.cs.md
@@ -172,6 +172,10 @@ public sealed class ListenBrainz : System.IDisposable {
 
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IEraActivity?> GetEraActivityAsync(string user, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
 
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IFoundFeedback> GetFeedbackForMessyRecordingAsync(System.Guid msid, int? score = default, int? count = default, int? offset = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IFoundFeedback> GetFeedbackForRecordingAsync(System.Guid mbid, int? score = default, int? count = default, int? offset = default, System.Threading.CancellationToken cancellationToken = default);
+
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IGenreActivity?> GetGenreActivityAsync(string user, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
 
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.ILatestImport> GetLatestImportAsync(string user, System.Threading.CancellationToken cancellationToken = default);
@@ -240,6 +244,8 @@ public sealed class ListenBrainz : System.IDisposable {
 
   [System.ObsoleteAttribute("Create a SubmittedListenData and pass it to the overload taking an ISubmittedListenData instead.")]
   public System.Threading.Tasks.Task SetNowPlayingAsync(string track, string artist, string? release = null, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task SubmitRecordingFeedbackAsync(MetaBrainz.ListenBrainz.Interfaces.ISubmittedRecordingFeedback feedback, System.Threading.CancellationToken cancellationToken = default);
 
   public System.Threading.Tasks.Task SubmitSingleListenAsync(MetaBrainz.ListenBrainz.Interfaces.ISubmittedListen listen, System.Threading.CancellationToken cancellationToken = default);
 
@@ -702,6 +708,30 @@ public interface IFetchedListens : MetaBrainz.Common.Json.IJsonBasedObject {
 }
 ```
 
+### Type: IFoundFeedback
+
+```cs
+public interface IFoundFeedback : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  int Count {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IRecordingFeedback> Feedback {
+    public abstract get;
+  }
+
+  int Offset {
+    public abstract get;
+  }
+
+  int TotalCount {
+    public abstract get;
+  }
+
+}
+```
+
 ### Type: IFoundPlaylists
 
 ```cs
@@ -1015,6 +1045,38 @@ public interface IPlayingTrack : MetaBrainz.Common.Json.IJsonBasedObject {
 }
 ```
 
+### Type: IRecordingFeedback
+
+```cs
+public interface IRecordingFeedback : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.DateTimeOffset Created {
+    public abstract get;
+  }
+
+  System.Guid? Id {
+    public abstract get;
+  }
+
+  System.Guid? MessyId {
+    public abstract get;
+  }
+
+  int Score {
+    public abstract get;
+  }
+
+  object? TrackMetadata {
+    public abstract get;
+  }
+
+  string User {
+    public abstract get;
+  }
+
+}
+```
+
 ### Type: IRecordingInfo
 
 ```cs
@@ -1321,6 +1383,26 @@ public interface ISubmittedListen : ISubmittedListenData {
 public interface ISubmittedListenData {
 
   ISubmittedTrackInfo Track {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: ISubmittedRecordingFeedback
+
+```cs
+public interface ISubmittedRecordingFeedback {
+
+  System.Guid? Id {
+    public abstract get;
+  }
+
+  System.Guid? MessyId {
+    public abstract get;
+  }
+
+  int Score {
     public abstract get;
   }
 
@@ -2034,6 +2116,31 @@ public class SubmittedListenData : MetaBrainz.ListenBrainz.Interfaces.ISubmitted
   [System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute]
   [System.ObsoleteAttribute("Use an object initializer to set the track info.")]
   public SubmittedListenData(string track, string artist, string? release = null);
+
+}
+```
+
+### Type: SubmittedRecordingFeedback
+
+```cs
+public sealed class SubmittedRecordingFeedback : MetaBrainz.ListenBrainz.Interfaces.ISubmittedRecordingFeedback {
+
+  System.Guid? Id {
+    public sealed override get;
+    public set;
+  }
+
+  System.Guid? MessyId {
+    public sealed override get;
+    public set;
+  }
+
+  int Score {
+    public sealed override get;
+    public set;
+  }
+
+  public SubmittedRecordingFeedback();
 
 }
 ```

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -172,6 +172,10 @@ public sealed class ListenBrainz : System.IDisposable {
 
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IEraActivity?> GetEraActivityAsync(string user, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
 
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IFoundFeedback> GetFeedbackForMessyRecordingAsync(System.Guid msid, int? score = default, int? count = default, int? offset = default, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IFoundFeedback> GetFeedbackForRecordingAsync(System.Guid mbid, int? score = default, int? count = default, int? offset = default, System.Threading.CancellationToken cancellationToken = default);
+
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.IGenreActivity?> GetGenreActivityAsync(string user, StatisticsRange? range = default, System.Threading.CancellationToken cancellationToken = default);
 
   public System.Threading.Tasks.Task<MetaBrainz.ListenBrainz.Interfaces.ILatestImport> GetLatestImportAsync(string user, System.Threading.CancellationToken cancellationToken = default);
@@ -240,6 +244,8 @@ public sealed class ListenBrainz : System.IDisposable {
 
   [System.ObsoleteAttribute("Create a SubmittedListenData and pass it to the overload taking an ISubmittedListenData instead.")]
   public System.Threading.Tasks.Task SetNowPlayingAsync(string track, string artist, string? release = null, System.Threading.CancellationToken cancellationToken = default);
+
+  public System.Threading.Tasks.Task SubmitRecordingFeedbackAsync(MetaBrainz.ListenBrainz.Interfaces.ISubmittedRecordingFeedback feedback, System.Threading.CancellationToken cancellationToken = default);
 
   public System.Threading.Tasks.Task SubmitSingleListenAsync(MetaBrainz.ListenBrainz.Interfaces.ISubmittedListen listen, System.Threading.CancellationToken cancellationToken = default);
 
@@ -702,6 +708,30 @@ public interface IFetchedListens : MetaBrainz.Common.Json.IJsonBasedObject {
 }
 ```
 
+### Type: IFoundFeedback
+
+```cs
+public interface IFoundFeedback : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  int Count {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IRecordingFeedback> Feedback {
+    public abstract get;
+  }
+
+  int Offset {
+    public abstract get;
+  }
+
+  int TotalCount {
+    public abstract get;
+  }
+
+}
+```
+
 ### Type: IFoundPlaylists
 
 ```cs
@@ -1015,6 +1045,38 @@ public interface IPlayingTrack : MetaBrainz.Common.Json.IJsonBasedObject {
 }
 ```
 
+### Type: IRecordingFeedback
+
+```cs
+public interface IRecordingFeedback : MetaBrainz.Common.Json.IJsonBasedObject {
+
+  System.DateTimeOffset Created {
+    public abstract get;
+  }
+
+  System.Guid? Id {
+    public abstract get;
+  }
+
+  System.Guid? MessyId {
+    public abstract get;
+  }
+
+  int Score {
+    public abstract get;
+  }
+
+  object? TrackMetadata {
+    public abstract get;
+  }
+
+  string User {
+    public abstract get;
+  }
+
+}
+```
+
 ### Type: IRecordingInfo
 
 ```cs
@@ -1321,6 +1383,26 @@ public interface ISubmittedListen : ISubmittedListenData {
 public interface ISubmittedListenData {
 
   ISubmittedTrackInfo Track {
+    public abstract get;
+  }
+
+}
+```
+
+### Type: ISubmittedRecordingFeedback
+
+```cs
+public interface ISubmittedRecordingFeedback {
+
+  System.Guid? Id {
+    public abstract get;
+  }
+
+  System.Guid? MessyId {
+    public abstract get;
+  }
+
+  int Score {
     public abstract get;
   }
 
@@ -2034,6 +2116,31 @@ public class SubmittedListenData : MetaBrainz.ListenBrainz.Interfaces.ISubmitted
   [System.Diagnostics.CodeAnalysis.SetsRequiredMembersAttribute]
   [System.ObsoleteAttribute("Use an object initializer to set the track info.")]
   public SubmittedListenData(string track, string artist, string? release = null);
+
+}
+```
+
+### Type: SubmittedRecordingFeedback
+
+```cs
+public sealed class SubmittedRecordingFeedback : MetaBrainz.ListenBrainz.Interfaces.ISubmittedRecordingFeedback {
+
+  System.Guid? Id {
+    public sealed override get;
+    public set;
+  }
+
+  System.Guid? MessyId {
+    public sealed override get;
+    public set;
+  }
+
+  int Score {
+    public sealed override get;
+    public set;
+  }
+
+  public SubmittedRecordingFeedback();
 
 }
 ```


### PR DESCRIPTION
| Endpoint                                      | Method                              |
|:----------------------------------------------|:------------------------------------|
| `/1/feedback/recording/xxx/get-feedback`      | `GetFeedbackForMessyRecordingAsync` |
| `/1/feedback/recording/xxx/get-feedback-mbid` | `GetFeedbackForRecordingAsync`      |
| `/1/feedback/recording-feedback`              | `SubmitRecordingFeedbackAsync`      |

Fixes #90.