### PR TITLE
Update year-in-music data support to current results

### DIFF
--- a/MetaBrainz.ListenBrainz/EndPoints/stats.user.year-in-music.http
+++ b/MetaBrainz.ListenBrainz/EndPoints/stats.user.year-in-music.http
@@ -12,3 +12,6 @@ GET https://api.listenbrainz.org/1/stats/user/{{lb-user-name}}/year-in-music/202
 
 ### 2024 Result Format
 GET https://api.listenbrainz.org/1/stats/user/{{lb-user-name}}/year-in-music/2024
+
+### 2025 Result Format
+GET https://api.listenbrainz.org/1/stats/user/{{lb-user-name}}/year-in-music/2025

--- a/MetaBrainz.ListenBrainz/Interfaces/IArtistStatistics.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IArtistStatistics.cs
@@ -18,6 +18,6 @@ public interface IArtistStatistics : IStatistics {
   int Offset { get; }
 
   /// <summary>The total number of (distinct) artists listened to.</summary>
-  public int TotalCount { get; }
+  int TotalCount { get; }
 
 }

--- a/MetaBrainz.ListenBrainz/Interfaces/IFoundFeedback.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IFoundFeedback.cs
@@ -8,15 +8,15 @@ namespace MetaBrainz.ListenBrainz.Interfaces;
 public interface IFoundFeedback : IJsonBasedObject {
 
   /// <summary>The maximum number of matches returned.</summary>
-  public int Count { get; }
+  int Count { get; }
 
   /// <summary>The feedback items that were found (if any).</summary>
-  public IReadOnlyList<IRecordingFeedback> Feedback { get; }
+  IReadOnlyList<IRecordingFeedback> Feedback { get; }
 
   /// <summary>The (0-based) offset of the returned feedback items from the start of the full set.</summary>
-  public int Offset { get; }
+  int Offset { get; }
 
   /// <summary>The total number of matching feedback items.</summary>
-  public int TotalCount { get; }
+  int TotalCount { get; }
 
 }

--- a/MetaBrainz.ListenBrainz/Interfaces/IFoundPlaylists.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IFoundPlaylists.cs
@@ -9,15 +9,15 @@ namespace MetaBrainz.ListenBrainz.Interfaces;
 public interface IFoundPlaylists : IJsonBasedObject {
 
   /// <summary>The maximum number of matches returned.</summary>
-  public int Count { get; }
+  int Count { get; }
 
   /// <summary>The (0-based) offset of the returned playlists from the start of the full set.</summary>
-  public int Offset { get; }
+  int Offset { get; }
 
   /// <summary>The playlists that were found (if any).</summary>
-  public IReadOnlyList<IPlaylist> Playlists { get; init; }
+  IReadOnlyList<IPlaylist> Playlists { get; init; }
 
   /// <summary>The total number of matching playlists.</summary>
-  public int TotalCount { get; }
+  int TotalCount { get; }
 
 }

--- a/MetaBrainz.ListenBrainz/Interfaces/IRecordingFeedback.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IRecordingFeedback.cs
@@ -8,25 +8,25 @@ namespace MetaBrainz.ListenBrainz.Interfaces;
 public interface IRecordingFeedback : IJsonBasedObject {
 
   /// <summary>The timestamp for the creation of this feedback.</summary>
-  public DateTimeOffset Created { get; }
+  DateTimeOffset Created { get; }
 
   /// <summary>The MusicBrainz ID identifying the recording.</summary>
-  public Guid? Id { get; }
+  Guid? Id { get; }
 
   /// <summary>The MessyBrainz ID identifying the recording.</summary>
-  public Guid? MessyId { get; }
+  Guid? MessyId { get; }
 
   /// <summary>The feedback score assigned by the user. 1 means they loved the recording; -1 means they hated it.</summary>
-  public int Score { get; }
+  int Score { get; }
 
   /// <summary>Extra metadata for the track.</summary>
   /// <remarks>
   /// This field is undocumented, but is currently returned by the feedback retrieval endpoints. It is expected to mostly (always?)
   /// be <see langword="null"/>.
   /// </remarks>
-  public object? TrackMetadata { get; }
+  object? TrackMetadata { get; }
 
   /// <summary>The user who submitted this feedback.</summary>
-  public string User { get; }
+  string User { get; }
 
 }

--- a/MetaBrainz.ListenBrainz/Interfaces/ISubmittedRecordingFeedback.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ISubmittedRecordingFeedback.cs
@@ -7,11 +7,11 @@ public interface ISubmittedRecordingFeedback {
 
   /// <summary>The MusicBrainz ID identifying the recording for which feedback is being provided.</summary>
   /// <remarks>When submitting, at least one of this property and <see cref="MessyId"/> must be set.</remarks>
-  public Guid? Id { get; }
+  Guid? Id { get; }
 
   /// <summary>The MessyBrainz ID identifying the recording for which feedback is being provided.</summary>
   /// <remarks>When submitting, at least one of this property and <see cref="Id"/> must be set.</remarks>
-  public Guid? MessyId { get; }
+  Guid? MessyId { get; }
 
   /// <summary>
   /// The score to submit.<br/>
@@ -35,6 +35,6 @@ public interface ISubmittedRecordingFeedback {
   ///   </item>
   /// </list>
   /// </summary>
-  public int Score { get; }
+  int Score { get; }
 
 }

--- a/MetaBrainz.ListenBrainz/Interfaces/ITokenValidationResult.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/ITokenValidationResult.cs
@@ -9,17 +9,17 @@ namespace MetaBrainz.ListenBrainz.Interfaces;
 public interface ITokenValidationResult {
 
   /// <summary>The status code for the request.</summary>
-  public HttpStatusCode Code { get; }
+  HttpStatusCode Code { get; }
 
   /// <summary>The message for the request.</summary>
-  public string Message { get; }
+  string Message { get; }
 
   /// <summary>The user name associated with the token.</summary>
-  public string? User { get; }
+  string? User { get; }
 
   /// <summary>
   /// Indicates whether or not the token was valid. If this is <see langword="null"/>, only the message indicates the validity.
   /// </summary>
-  public bool? Valid { get; }
+  bool? Valid { get; }
 
 }

--- a/MetaBrainz.ListenBrainz/Interfaces/IYearInMusicData.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IYearInMusicData.cs
@@ -60,11 +60,8 @@ public interface IYearInMusicData : IJsonBasedObject {
   /// <remarks>This field is only provided for the Year in Music 2023 and later.</remarks>
   int? ReleaseGroupCount { get; }
 
-  /// <summary>
-  /// Users with tastes similar to this one.<br/>
-  /// The key is the user ID, the value is the degree of similarity (between 0 and 1, so multiply by 100 for the percentage.
-  /// </summary>
-  IReadOnlyDictionary<string, decimal>? SimilarUsers { get; }
+  /// <summary>Users with tastes similar to this one.</summary>
+  IReadOnlySet<ISimilarUser>? SimilarUsers { get; }
 
   /// <summary>Information about a user's top artists.</summary>
   IReadOnlyList<ITopArtist>? TopArtists { get; }

--- a/MetaBrainz.ListenBrainz/Interfaces/IYearInMusicData.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IYearInMusicData.cs
@@ -14,12 +14,19 @@ public interface IYearInMusicData : IJsonBasedObject {
   /// <remarks>This field is only provided for the Year in Music 2022 and later.</remarks>
   int? ArtistCount { get; }
 
+  /// <summary>Artist listening information over the course of the year.</summary>
+  /// <remarks>This field is only provided for the Year in Music 2022 and later.</remarks>
+  IReadOnlyList<IArtistTimeRange>? ArtistEvolutionActivity { get; }
+
   /// <summary>Information about artist listen counts, grouped by country.</summary>
   /// <remarks>This field is only provided for the Year in Music 2022 and later.</remarks>
   IReadOnlyList<IArtistCountryInfo>? ArtistMap { get; }
 
   /// <summary>The weekday that sees the most listens recorded.</summary>
   string? DayOfWeek { get; }
+
+  /// <summary>Listening information grouped by genre and hour of day.</summary>
+  IReadOnlyList<IGenreActivityDetails>? GenreActivity { get; }
 
   /// <summary>The total number of listens that were recorded over the course of the year.</summary>
   int? ListenCount { get; }

--- a/MetaBrainz.ListenBrainz/Json/Readers/ArtistTimeRangeReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ArtistTimeRangeReader.cs
@@ -35,7 +35,12 @@ internal class ArtistTimeRangeReader : ObjectReader<ArtistTimeRange> {
             break;
           case "time_unit": {
             // LB-1833: the sitewide endpoints return integer values (days-of-month or year, so ushort is enough as a range)
-            timeUnit = reader.TryGetUInt16(out var number) ? number.ToString(CultureInfo.InvariantCulture) : reader.GetString();
+            if (reader.TokenType == JsonTokenType.Number && reader.TryGetUInt16(out var number)) {
+              timeUnit = number.ToString(CultureInfo.InvariantCulture);
+            }
+            else {
+              timeUnit = reader.GetString();
+            }
             break;
           }
           default:

--- a/MetaBrainz.ListenBrainz/Json/Readers/YearInMusicDataReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/YearInMusicDataReader.cs
@@ -18,11 +18,13 @@ internal sealed class YearInMusicDataReader : ObjectReader<YearInMusicData> {
   public static readonly YearInMusicDataReader Instance = new();
 
   protected override YearInMusicData ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+    IReadOnlyList<IArtistTimeRange>? artistActivity = null;
     int? artistCount = null;
     IReadOnlyList<IArtistCountryInfo>? artistMap = null;
     string? dayOfWeek = null;
     IReadOnlyDictionary<string, Uri>? discoveriesCoverArt = null;
     IPlaylist? discoveriesPlaylist = null;
+    IReadOnlyList<IGenreActivityDetails>? genreActivity = null;
     int? listenCount = null;
     double? listenedMinutes = null;
     IReadOnlyList<IListenTimeRange>? listensPerDay = null;
@@ -52,11 +54,17 @@ internal sealed class YearInMusicDataReader : ObjectReader<YearInMusicData> {
       try {
         reader.Read();
         switch (prop) {
+          case "artist_evolution_activity":
+            artistActivity = reader.ReadList(ArtistTimeRangeReader.Instance, options);
+            break;
           case "artist_map":
             artistMap = reader.ReadList(ArtistCountryInfoReader.Instance, options);
             break;
           case "day_of_week":
             dayOfWeek = reader.GetString();
+            break;
+          case "genre_activity":
+            genreActivity = reader.ReadList(GenreActivityDetailsReader.Instance, options);
             break;
           case "listens_per_day":
             listensPerDay = reader.ReadList(ListenTimeRangeReader.Instance, options);
@@ -154,8 +162,10 @@ internal sealed class YearInMusicDataReader : ObjectReader<YearInMusicData> {
     TimeSpan? listeningTime = listenedMinutes is null ? null : TimeSpan.FromSeconds(listenedMinutes.Value);
     return new YearInMusicData {
       ArtistCount = artistCount,
+      ArtistEvolutionActivity = artistActivity,
       ArtistMap = artistMap,
       DayOfWeek = dayOfWeek,
+      GenreActivity = genreActivity,
       ListenCount = listenCount,
       ListeningTime = listeningTime,
       ListensPerDay = listensPerDay,

--- a/MetaBrainz.ListenBrainz/Json/Readers/YearInMusicDataReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/YearInMusicDataReader.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 
 using MetaBrainz.Common.Json;
@@ -164,7 +166,7 @@ internal sealed class YearInMusicDataReader : ObjectReader<YearInMusicData> {
       RecordingCount = recordingCount,
       ReleaseCount = releaseCount,
       ReleaseGroupCount = releaseGroupCount,
-      SimilarUsers = similarUsers,
+      SimilarUsers = similarUsers?.Select(YearInMusicDataReader.SimilarUserFromDictionaryEntry).ToHashSet(),
       TopArtists = topArtists,
       TopGenres = topGenres,
       TopDiscoveriesPlaylist = discoveriesPlaylist,
@@ -182,5 +184,10 @@ internal sealed class YearInMusicDataReader : ObjectReader<YearInMusicData> {
       UnhandledProperties = rest,
     };
   }
+
+  private static ISimilarUser SimilarUserFromDictionaryEntry(KeyValuePair<string, decimal> item) => new SimilarUser {
+    Name = item.Key,
+    Similarity = item.Value * 100
+  };
 
 }

--- a/MetaBrainz.ListenBrainz/Objects/SimilarUser.cs
+++ b/MetaBrainz.ListenBrainz/Objects/SimilarUser.cs
@@ -5,6 +5,8 @@ namespace MetaBrainz.ListenBrainz.Objects;
 
 internal sealed class SimilarUser : JsonBasedObject, ISimilarUser {
 
+  public override int GetHashCode() => this.Name.GetHashCode();
+
   public required string Name { get; init; }
 
   public required decimal Similarity { get; init; }

--- a/MetaBrainz.ListenBrainz/Objects/YearInMusicData.cs
+++ b/MetaBrainz.ListenBrainz/Objects/YearInMusicData.cs
@@ -35,6 +35,8 @@ internal sealed class YearInMusicData : JsonBasedObject, IYearInMusicData {
 
   public int? ReleaseGroupCount { get; init; }
 
+  public IReadOnlySet<ISimilarUser>? SimilarUsers { get; init; }
+
   public IReadOnlyList<ITopArtist>? TopArtists { get; init; }
 
   public IPlaylist? TopDiscoveriesPlaylist { get; init; }
@@ -56,8 +58,6 @@ internal sealed class YearInMusicData : JsonBasedObject, IYearInMusicData {
   public IPlaylist? TopRecordingsPlaylist { get; init; }
 
   public IReadOnlyDictionary<string, Uri>? TopRecordingsPlaylistCoverArt { get; init; }
-
-  public IReadOnlyDictionary<string, decimal>? SimilarUsers { get; init; }
 
   public IReadOnlyList<IReleaseGroupInfo>? TopReleaseGroups { get; init; }
 

--- a/MetaBrainz.ListenBrainz/Objects/YearInMusicData.cs
+++ b/MetaBrainz.ListenBrainz/Objects/YearInMusicData.cs
@@ -11,9 +11,13 @@ internal sealed class YearInMusicData : JsonBasedObject, IYearInMusicData {
 
   public int? ArtistCount { get; init; }
 
+  public IReadOnlyList<IArtistTimeRange>? ArtistEvolutionActivity { get; init; }
+
   public IReadOnlyList<IArtistCountryInfo>? ArtistMap { get; init; }
 
   public string? DayOfWeek { get; init; }
+
+  public IReadOnlyList<IGenreActivityDetails>? GenreActivity { get; init; }
 
   public int? ListenCount { get; init; }
 

--- a/public-api/MetaBrainz.ListenBrainz.net10.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net10.0.cs.md
@@ -1650,11 +1650,19 @@ public interface IYearInMusicData : MetaBrainz.Common.Json.IJsonBasedObject {
     public abstract get;
   }
 
+  System.Collections.Generic.IReadOnlyList<IArtistTimeRange>? ArtistEvolutionActivity {
+    public abstract get;
+  }
+
   System.Collections.Generic.IReadOnlyList<IArtistCountryInfo>? ArtistMap {
     public abstract get;
   }
 
   string? DayOfWeek {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IGenreActivityDetails>? GenreActivity {
     public abstract get;
   }
 

--- a/public-api/MetaBrainz.ListenBrainz.net10.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net10.0.cs.md
@@ -1698,7 +1698,7 @@ public interface IYearInMusicData : MetaBrainz.Common.Json.IJsonBasedObject {
     public abstract get;
   }
 
-  System.Collections.Generic.IReadOnlyDictionary<string, decimal>? SimilarUsers {
+  System.Collections.Generic.IReadOnlySet<ISimilarUser>? SimilarUsers {
     public abstract get;
   }
 

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -1650,11 +1650,19 @@ public interface IYearInMusicData : MetaBrainz.Common.Json.IJsonBasedObject {
     public abstract get;
   }
 
+  System.Collections.Generic.IReadOnlyList<IArtistTimeRange>? ArtistEvolutionActivity {
+    public abstract get;
+  }
+
   System.Collections.Generic.IReadOnlyList<IArtistCountryInfo>? ArtistMap {
     public abstract get;
   }
 
   string? DayOfWeek {
+    public abstract get;
+  }
+
+  System.Collections.Generic.IReadOnlyList<IGenreActivityDetails>? GenreActivity {
     public abstract get;
   }
 

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -1698,7 +1698,7 @@ public interface IYearInMusicData : MetaBrainz.Common.Json.IJsonBasedObject {
     public abstract get;
   }
 
-  System.Collections.Generic.IReadOnlyDictionary<string, decimal>? SimilarUsers {
+  System.Collections.Generic.IReadOnlySet<ISimilarUser>? SimilarUsers {
     public abstract get;
   }
 


### PR DESCRIPTION
This adds artist evolution activity and genre activity.

It also changes the "similar users" data to use `ISimilarUser` instead of a raw dictionary, which is a breaking change.
