### PR TITLE
Handle changed payloads

### DIFF
--- a/MetaBrainz.ListenBrainz/Interfaces/IArtistActivity.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IArtistActivity.cs
@@ -1,11 +1,9 @@
 ﻿using System.Collections.Generic;
 
-using MetaBrainz.Common.Json;
-
 namespace MetaBrainz.ListenBrainz.Interfaces;
 
 /// <summary>Artist-oriented listening statistics.</summary>
-public interface IArtistActivity : IJsonBasedObject {
+public interface IArtistActivity : IStatistics {
 
   /// <summary>Listening statistics for a number of artists.</summary>
   IReadOnlyList<IArtistActivityInfo> Artists { get; }

--- a/MetaBrainz.ListenBrainz/Interfaces/IArtistEvolutionActivity.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IArtistEvolutionActivity.cs
@@ -6,6 +6,6 @@ namespace MetaBrainz.ListenBrainz.Interfaces;
 public interface IArtistEvolutionActivity : IStatistics {
 
   /// <summary>Artist listening information over a given period of time.</summary>
-  IReadOnlyList<IArtistTimeRange>? Activity { get; }
+  IReadOnlyList<IArtistTimeRange> Activity { get; }
 
 }

--- a/MetaBrainz.ListenBrainz/Interfaces/IGenreActivity.cs
+++ b/MetaBrainz.ListenBrainz/Interfaces/IGenreActivity.cs
@@ -1,13 +1,11 @@
 ﻿using System.Collections.Generic;
 
-using MetaBrainz.Common.Json;
-
 namespace MetaBrainz.ListenBrainz.Interfaces;
 
 /// <summary>Listening information by genre and hour of day.</summary>
-public interface IGenreActivity : IJsonBasedObject {
+public interface IGenreActivity : IStatistics {
 
   /// <summary>Listening information grouped by genre and hour of day.</summary>
-  IReadOnlyList<IGenreActivityDetails>? Activity { get; }
+  IReadOnlyList<IGenreActivityDetails> Activity { get; }
 
 }

--- a/MetaBrainz.ListenBrainz/Json/Readers/AristEvolutionActivityReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/AristEvolutionActivityReader.cs
@@ -63,7 +63,7 @@ internal sealed class ArtistEvolutionActivityReader : PayloadReader<ArtistEvolut
       reader.Read();
     }
     return new ArtistEvolutionActivity {
-      Activity = activity,
+      Activity = activity ?? throw new JsonException("Expected artist evolution activity not found or null."),
       LastUpdated = lastUpdated ?? throw new JsonException("Expected last-updated timestamp not found or null."),
       NewestListen = newestListen,
       OldestListen = oldestListen,

--- a/MetaBrainz.ListenBrainz/Json/Readers/ArtistActivityReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/ArtistActivityReader.cs
@@ -3,25 +3,51 @@ using System.Collections.Generic;
 using System.Text.Json;
 
 using MetaBrainz.Common.Json;
-using MetaBrainz.Common.Json.Converters;
 using MetaBrainz.ListenBrainz.Objects;
 
 namespace MetaBrainz.ListenBrainz.Json.Readers;
 
-internal class ArtistActivityReader : ObjectReader<ArtistActivity> {
+internal class ArtistActivityReader : PayloadReader<ArtistActivity> {
 
   public static readonly ArtistActivityReader Instance = new();
 
-  protected override ArtistActivity ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+  protected override ArtistActivity ReadPayload(ref Utf8JsonReader reader, JsonSerializerOptions options) {
     IReadOnlyList<ArtistActivityInfo>? artists = null;
+    DateTimeOffset? lastUpdated = null;
+    DateTimeOffset? newestListen = null;
+    DateTimeOffset? oldestListen = null;
+    StatisticsRange? range = null;
+    string? user = null;
     Dictionary<string, object?>? rest = null;
     while (reader.TokenType == JsonTokenType.PropertyName) {
       var prop = reader.GetPropertyName();
       try {
         reader.Read();
         switch (prop) {
-          case "result":
+          case "artist_activity":
             artists = reader.ReadList(ArtistActivityInfoReader.Instance, options);
+            break;
+          case "from_ts": {
+            var unixTime = reader.GetOptionalInt64();
+            oldestListen = unixTime is null ? null : DateTimeOffset.FromUnixTimeSeconds(unixTime.Value);
+            break;
+          }
+          case "last_updated":
+            lastUpdated = DateTimeOffset.FromUnixTimeSeconds(reader.GetInt64());
+            break;
+          case "range":
+            range = EnumHelper.ParseStatisticsRange(reader.GetString());
+            if (range == StatisticsRange.Unknown) {
+              goto default; // also register it as an unhandled property
+            }
+            break;
+          case "to_ts": {
+            var unixTime = reader.GetOptionalInt64();
+            newestListen = unixTime is null ? null : DateTimeOffset.FromUnixTimeSeconds(unixTime.Value);
+            break;
+          }
+          case "user_id":
+            user = reader.GetString();
             break;
           default:
             rest ??= [ ];
@@ -35,8 +61,13 @@ internal class ArtistActivityReader : ObjectReader<ArtistActivity> {
       reader.Read();
     }
     return new ArtistActivity {
-      Artists = artists ?? throw new JsonException("Expected result set not found or null."),
+      Artists = artists ?? throw new JsonException("Expected artist activity not found or null."),
+      LastUpdated = lastUpdated ?? throw new JsonException("Expected last-updated timestamp not found or null."),
+      NewestListen = newestListen,
+      OldestListen = oldestListen,
+      Range = range ?? throw new JsonException("Expected range not found or null."),
       UnhandledProperties = rest,
+      User = user,
     };
   }
 

--- a/MetaBrainz.ListenBrainz/Json/Readers/GenreActivityReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/GenreActivityReader.cs
@@ -3,26 +3,52 @@ using System.Collections.Generic;
 using System.Text.Json;
 
 using MetaBrainz.Common.Json;
-using MetaBrainz.Common.Json.Converters;
 using MetaBrainz.ListenBrainz.Interfaces;
 using MetaBrainz.ListenBrainz.Objects;
 
 namespace MetaBrainz.ListenBrainz.Json.Readers;
 
-internal sealed class GenreActivityReader : ObjectReader<GenreActivity> {
+internal sealed class GenreActivityReader : PayloadReader<GenreActivity> {
 
   public static readonly GenreActivityReader Instance = new();
 
-  protected override GenreActivity ReadObjectContents(ref Utf8JsonReader reader, JsonSerializerOptions options) {
+  protected override GenreActivity ReadPayload(ref Utf8JsonReader reader, JsonSerializerOptions options) {
     IReadOnlyList<IGenreActivityDetails>? activity = null;
+    DateTimeOffset? lastUpdated = null;
+    DateTimeOffset? newestListen = null;
+    DateTimeOffset? oldestListen = null;
+    StatisticsRange? range = null;
+    string? user = null;
     Dictionary<string, object?>? rest = null;
     while (reader.TokenType == JsonTokenType.PropertyName) {
       var prop = reader.GetPropertyName();
       try {
         reader.Read();
         switch (prop) {
-          case "result":
+          case "from_ts": {
+            var unixTime = reader.GetOptionalInt64();
+            oldestListen = unixTime is null ? null : DateTimeOffset.FromUnixTimeSeconds(unixTime.Value);
+            break;
+          }
+          case "genre_activity":
             activity = reader.ReadList(GenreActivityDetailsReader.Instance, options);
+            break;
+          case "last_updated":
+            lastUpdated = DateTimeOffset.FromUnixTimeSeconds(reader.GetInt64());
+            break;
+          case "range":
+            range = EnumHelper.ParseStatisticsRange(reader.GetString());
+            if (range == StatisticsRange.Unknown) {
+              goto default; // also register it as an unhandled property
+            }
+            break;
+          case "to_ts": {
+            var unixTime = reader.GetOptionalInt64();
+            newestListen = unixTime is null ? null : DateTimeOffset.FromUnixTimeSeconds(unixTime.Value);
+            break;
+          }
+          case "user_id":
+            user = reader.GetString();
             break;
           default:
             rest ??= [ ];
@@ -35,11 +61,14 @@ internal sealed class GenreActivityReader : ObjectReader<GenreActivity> {
       }
       reader.Read();
     }
-    if (activity is null) {
-      throw new JsonException("Expected result set not found or null.");
-    }
     return new GenreActivity {
-      Activity = activity,
+      Activity = activity ?? throw new JsonException("Expected genre activity not found or null."),
+      LastUpdated = lastUpdated ?? throw new JsonException("Expected last-updated timestamp not found or null."),
+      NewestListen = newestListen,
+      OldestListen = oldestListen,
+      Range = range ?? throw new JsonException("Expected range not found or null."),
+      UnhandledProperties = rest,
+      User = user,
     };
   }
 

--- a/MetaBrainz.ListenBrainz/Json/Readers/YearInMusicDataReader.cs
+++ b/MetaBrainz.ListenBrainz/Json/Readers/YearInMusicDataReader.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;

--- a/MetaBrainz.ListenBrainz/Objects/ArtistActivity.cs
+++ b/MetaBrainz.ListenBrainz/Objects/ArtistActivity.cs
@@ -1,11 +1,10 @@
 ﻿using System.Collections.Generic;
 
-using MetaBrainz.Common.Json;
 using MetaBrainz.ListenBrainz.Interfaces;
 
 namespace MetaBrainz.ListenBrainz.Objects;
 
-internal sealed class ArtistActivity : JsonBasedObject, IArtistActivity {
+internal sealed class ArtistActivity : Statistics, IArtistActivity {
 
   public required IReadOnlyList<IArtistActivityInfo> Artists { get; init; }
 

--- a/MetaBrainz.ListenBrainz/Objects/ArtistEvolutionActivity.cs
+++ b/MetaBrainz.ListenBrainz/Objects/ArtistEvolutionActivity.cs
@@ -6,6 +6,6 @@ namespace MetaBrainz.ListenBrainz.Objects;
 
 internal sealed class ArtistEvolutionActivity : Statistics, IArtistEvolutionActivity {
 
-  public IReadOnlyList<IArtistTimeRange>? Activity { get; init; }
+  public required IReadOnlyList<IArtistTimeRange> Activity { get; init; }
 
 }

--- a/MetaBrainz.ListenBrainz/Objects/GenreActivity.cs
+++ b/MetaBrainz.ListenBrainz/Objects/GenreActivity.cs
@@ -1,12 +1,11 @@
 ﻿using System.Collections.Generic;
 
-using MetaBrainz.Common.Json;
 using MetaBrainz.ListenBrainz.Interfaces;
 
 namespace MetaBrainz.ListenBrainz.Objects;
 
-internal sealed class GenreActivity : JsonBasedObject, IGenreActivity {
+internal sealed class GenreActivity : Statistics, IGenreActivity {
 
-  public IReadOnlyList<IGenreActivityDetails>? Activity { get; init; }
+  public required IReadOnlyList<IGenreActivityDetails> Activity { get; init; }
 
 }

--- a/public-api/MetaBrainz.ListenBrainz.net10.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net10.0.cs.md
@@ -748,9 +748,9 @@ public interface IFoundPlaylists : MetaBrainz.Common.Json.IJsonBasedObject {
 ### Type: IGenreActivity
 
 ```cs
-public interface IGenreActivity : MetaBrainz.Common.Json.IJsonBasedObject {
+public interface IGenreActivity : IStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
 
-  System.Collections.Generic.IReadOnlyList<IGenreActivityDetails>? Activity {
+  System.Collections.Generic.IReadOnlyList<IGenreActivityDetails> Activity {
     public abstract get;
   }
 

--- a/public-api/MetaBrainz.ListenBrainz.net10.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net10.0.cs.md
@@ -431,7 +431,7 @@ public interface IAlbumInfo : MetaBrainz.Common.Json.IJsonBasedObject {
 ### Type: IArtistActivity
 
 ```cs
-public interface IArtistActivity : MetaBrainz.Common.Json.IJsonBasedObject {
+public interface IArtistActivity : IStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
 
   System.Collections.Generic.IReadOnlyList<IArtistActivityInfo> Artists {
     public abstract get;

--- a/public-api/MetaBrainz.ListenBrainz.net10.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net10.0.cs.md
@@ -513,7 +513,7 @@ public interface IArtistCredit {
 ```cs
 public interface IArtistEvolutionActivity : IStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
 
-  System.Collections.Generic.IReadOnlyList<IArtistTimeRange>? Activity {
+  System.Collections.Generic.IReadOnlyList<IArtistTimeRange> Activity {
     public abstract get;
   }
 

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -748,9 +748,9 @@ public interface IFoundPlaylists : MetaBrainz.Common.Json.IJsonBasedObject {
 ### Type: IGenreActivity
 
 ```cs
-public interface IGenreActivity : MetaBrainz.Common.Json.IJsonBasedObject {
+public interface IGenreActivity : IStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
 
-  System.Collections.Generic.IReadOnlyList<IGenreActivityDetails>? Activity {
+  System.Collections.Generic.IReadOnlyList<IGenreActivityDetails> Activity {
     public abstract get;
   }
 

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -431,7 +431,7 @@ public interface IAlbumInfo : MetaBrainz.Common.Json.IJsonBasedObject {
 ### Type: IArtistActivity
 
 ```cs
-public interface IArtistActivity : MetaBrainz.Common.Json.IJsonBasedObject {
+public interface IArtistActivity : IStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
 
   System.Collections.Generic.IReadOnlyList<IArtistActivityInfo> Artists {
     public abstract get;

--- a/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.ListenBrainz.net8.0.cs.md
@@ -513,7 +513,7 @@ public interface IArtistCredit {
 ```cs
 public interface IArtistEvolutionActivity : IStatistics, MetaBrainz.Common.Json.IJsonBasedObject {
 
-  System.Collections.Generic.IReadOnlyList<IArtistTimeRange>? Activity {
+  System.Collections.Generic.IReadOnlyList<IArtistTimeRange> Activity {
     public abstract get;
   }
 


### PR DESCRIPTION
This fixes retrieval of artist and genre activity, which were changed to return proper statistics payloads (which means they also provide new properties).
